### PR TITLE
experiment setup pages navigatable & added CageSetup prototype

### DIFF
--- a/CageSetupFrame.py
+++ b/CageSetupFrame.py
@@ -120,16 +120,3 @@ class CageSetupFrame(Frame):
     def get_num_animals(self):
         return self.num_animals
 
-
-
-if __name__ == '__main__':
-    root = Tk()
-    root.title("Mouser")
-    root.geometry('600x600')
-
-    main_frame = CageSetupFrame(root, "Main").grid(sticky=E)
-    frame = CageSetupFrame(root, main_frame)
-    frame.raise_frame()
-
-    root.mainloop()
-###############################################################

--- a/CageSetupFrame.py
+++ b/CageSetupFrame.py
@@ -1,0 +1,135 @@
+from operator import indexOf
+from tkinter import *
+from tkinter.ttk import *
+from NavigateButton import *
+import array
+
+class CageSetupFrame(Frame):
+    def __init__(self, parent: Tk, prev_page: Frame = None, next_page: Frame = None):
+        super().__init__(parent)
+
+        ### demo animal data ###
+        animals = [ ('1', '26.45', '123456AV12', '1', '1'),
+                    ('2','21.59', '654321QR07', '1', '2') 
+        ]
+        ##########################
+
+        self.pad_x = 8
+        self.pad_y = 18
+        self.label_font = ("Arial", 13)
+
+        self.num_cages = 0
+        self.num_animals = 0
+
+        self.grid(row=6, column=6, sticky='NESW')
+
+        title_label = Label(self, text='Experiment Setup', font=("Arial", 25))
+        title_label.grid(row=0, column=1, columnspan=3, padx=self.pad_x, pady=self.pad_y)
+
+        cage_label = Label(self, text='Number of\nCages', font=self.label_font)
+        animal_label = Label(self, text='Number of Animals\nPer Cage', font=self.label_font)
+        reset_label = Label(self, text='Reset Animal\nCages', font=self.label_font)
+
+        cage_label.grid(row=1, column=0, padx=self.pad_x, pady=self.pad_y)
+        animal_label.grid(row=1, column=2, padx=self.pad_x, pady=self.pad_y)
+        reset_label.grid(row=3, column=0, padx=self.pad_x, pady=self.pad_y)
+
+        self.num_cages_input = Entry(self, width=8, font=self.label_font)
+        self.num_animal_input = Entry(self, width=8, font=self.label_font)
+        self.animal_id = Entry(self, width=8, font=self.label_font)
+        self.cage_id = Entry(self, width=8, font=self.label_font)    
+
+        self.animal_id.insert(0, 'animal ID')
+        self.cage_id.insert(0, 'cage ID')
+
+        self.num_cages_input.grid(row=1, column=1, padx=self.pad_x, pady=self.pad_y)
+        self.num_animal_input.grid(row=1, column=3, padx=self.pad_x, pady=self.pad_y)
+        self.animal_id.grid(row=3, column=1, padx=self.pad_x, pady=self.pad_y)
+        self.cage_id.grid(row=3, column=2, padx=self.pad_x, pady=self.pad_y)
+
+        table = self.create_table(animals)
+        table.grid(row=2, column=0, columnspan=6, padx=self.pad_x, pady=self.pad_y)
+
+        set_button = Button(self, text='Set', width=15, command=lambda: self.set_cages())
+        reset_button = Button(self, text='Reset', width=15, command=lambda: self.reset_cages())
+        reset_all_button = Button(self, text='Reset All', width=15, command=lambda: self.reset_all_cages())
+        save_button = Button(self, text='Save', width=15, command=lambda: self.save_cages('temp'))
+        
+        set_button.grid(row=1, column=5, padx=self.pad_x, pady=self.pad_y)
+        reset_button.grid(row=3, column=3, padx=self.pad_x, pady=self.pad_y)
+        reset_all_button.grid(row=4, column=3, padx=self.pad_x, pady=self.pad_y)
+        save_button.grid(row=4, column=5, padx=self.pad_x, pady=self.pad_y)
+
+        prev_button = NavigateButton(self, 'Previous', prev_page)
+        next_button = NavigateButton(self, 'Next', next_page)
+        prev_button.grid(row=5, column=0, columnspan=2, padx=self.pad_x, pady=self.pad_y, sticky=W)
+        next_button.grid(row=5, column=5, columnspan=2, padx=self.pad_x, pady=self.pad_y, sticky=E)
+
+
+        for i in range(0,5):
+            if i < 4:
+                self.grid_rowconfigure(i, weight=1)
+            self.grid_columnconfigure(i, weight=1)
+
+
+    def raise_frame(frame: Frame):
+        frame.tkraise()
+
+
+    def create_table(self, animals: array):
+        table = LabelFrame(self, height=200, width=(600 - self.pad_x*2), relief=RIDGE)
+        table.grid(row=len(animals)+1, column=5)
+
+        labels = ['ID', 'Animal Weight\n(pounds)', 'RFID', 'Group', 'Cage Number']
+        for i in range(0, len(labels)):
+            Label(table, text=labels[i], font=self.label_font, padding=15).grid(row=0, column=i)
+            table.grid_columnconfigure(i, weight=1) 
+            for animal in animals:
+                Label(table, text=animal[i], font=self.label_font, padding=15).grid(
+                    row=animals.index(animal)+1, column=i)
+                table.grid_rowconfigure(i+1, weight=1)
+        return table
+
+
+
+    def set_cages(self):
+        self.num_cages = self.num_cages_input.get()
+        self.num_animals = self.num_animal_input.get()
+
+
+    def reset_cages(self, animal_id, cage_id):
+        # TO-DO implement
+        return
+
+
+    def reset_all_cages(self):
+        # TO-DO implement
+        return
+
+    def save_cages(self, cages):
+        # TO-DO : 
+        #   save to file / database
+        #   disable text fields, save button
+        return
+
+
+    def get_num_cages(self):
+        return self.num_cages
+
+
+    def get_num_animals(self):
+        return self.num_animals
+
+
+
+if __name__ == '__main__':
+    root = Tk()
+    root.title("Mouser")
+    root.geometry('600x600')
+
+    main_frame = CageSetupFrame(root, "Main").grid(sticky=E)
+    frame = CageSetupFrame(root, main_frame)
+    frame.raise_frame()
+
+    root.mainloop()
+###############################################################

--- a/ExperimentSetupFrame.py
+++ b/ExperimentSetupFrame.py
@@ -1,11 +1,13 @@
 from tkinter import *
 from tkinter.ttk import *
-
 from NavigateButton import *
+from IdSetupFrame import IdSetupFrame
 
 class ExperimentSetupFrame(Frame):
     def __init__(self, parent: Tk, prev_page: Frame = None):
         super().__init__(parent)
+       
+        self.root = parent
 
         # vars for user input
         self.exper_name = ''
@@ -14,41 +16,43 @@ class ExperimentSetupFrame(Frame):
         self.measurement_items = []
         self.species = ''
 
-        padX = 10
-        padY = 20
+        pad_x = 10
+        pad_y = 20
         label_font = ("Arial", 13)
-
         
         self.grid(row=5, column=4, sticky='NESW')
 
         title_label = Label(self, text='Experiment Setup', font=("Arial", 25))
-        title_label.grid(row=0, column=1, columnspan=2, padx=padX, pady=padY, sticky=N)
+        title_label.grid(row=0, column=1, columnspan=2, padx=pad_x, pady=pad_y)
 
-        name_label = Label(self, text='Experiment Name', font=label_font).grid(row=1, column=0, padx=padX, pady=padY, sticky=W)
-        invest_label = Label(self, text='Investigators', font=label_font).grid(row=2, column=0, padx=padX, pady=padY, sticky=W)
-        spec_label = Label(self, text='Species', font=label_font).grid(row=3, column=0, padx=padX, pady=padY, sticky=W)
-        meas_item_label = Label(self, text='Measurement Items', font=label_font).grid(row=4, column=0, padx=padX, pady=padY, sticky=W)
+        Label(self, text='Experiment Name', font=label_font).grid(row=1, column=0, padx=pad_x, pady=pad_y, sticky=W)
+        Label(self, text='Investigators', font=label_font).grid(row=2, column=0, padx=pad_x, pady=pad_y, sticky=W)
+        Label(self, text='Species', font=label_font).grid(row=3, column=0, padx=pad_x, pady=pad_y, sticky=W)
+        Label(self, text='Measurement Items', font=label_font).grid(row=4, column=0, padx=pad_x, pady=pad_y, sticky=W)
 
-        self.name_text = Text(self, height=1, width=30, font=label_font).grid(row=1, column=1, columnspan=2, padx=padX, pady=padY)
-        self.spec_text = Text(self, height=1, width=30, font=label_font).grid(row=3, column=1, columnspan=2, padx=padX, pady=padY)
-        self.meas_item_text = Text(self, height=1, width=30, font=label_font).grid(row=4, column=1, columnspan=2, padx=padX, pady=padY)
+        self.name_text = Text(self, height=1, width=30, font=label_font).grid(row=1, column=1, columnspan=2, padx=pad_x, pady=pad_y)
+        self.spec_text = Text(self, height=1, width=30, font=label_font).grid(row=3, column=1, columnspan=2, padx=pad_x, pady=pad_y)
+        self.meas_item_text = Text(self, height=1, width=30, font=label_font).grid(row=4, column=1, columnspan=2, padx=pad_x, pady=pad_y)
 
         self.options = StringVar()
         invest_drop = OptionMenu(self, self.options, self.investigators[0], *self.investigators, command=self.callback)
         invest_drop.config(width=40) 
         invest_drop['menu'].config(font=label_font)
-        invest_drop.grid(row=2, column=1, columnspan=2, padx=padX, pady=padY)
+        invest_drop.grid(row=2, column=1, columnspan=2, padx=pad_x, pady=pad_y)
         self.options.set(self.investigators[0])
         self.selected = ''
 
         invest_button = Button(self, text='Add', width=15, command=lambda: self.get_investigators())
-        invest_button.grid(row=2, column=3, padx=padX, pady=padY,sticky=E)
+        invest_button.grid(row=2, column=3, padx=pad_x, pady=pad_y,sticky=E)
         
         measure_button = Button(self, text='Add', width=15, command=lambda: self.add_items())
-        measure_button.grid(row=4, column=3, padx=padX, pady=padY,sticky=E)
+        measure_button.grid(row=4, column=3, padx=pad_x, pady=pad_y,sticky=E)
 
-        # TO-DO connect next page when made
-        next_button = NavigateButton(self, 'Next', self).grid(row=5, column=3, padx=padX, pady=padY,sticky=E)
+
+        back_button = NavigateButton(self, 'Back', prev_page)
+        next_button = Button(self, text='Next', width=15, command=lambda: self.create_next(self))
+        back_button.grid(row=5, column=0, padx=pad_x, pady=pad_y, sticky=W)
+        next_button.grid(row=5, column=3, padx=pad_x, pady=pad_y, sticky=E)
 
         for i in range (0, 5):
             if i < 5:
@@ -60,6 +64,11 @@ class ExperimentSetupFrame(Frame):
 
 
 
+    def create_next(self, frame: Frame):
+        next = IdSetupFrame(self.root, frame)
+        next.grid(row=0, column=0)
+
+
     def raise_frame(frame: Frame):
         frame.tkraise()
 
@@ -67,45 +76,3 @@ class ExperimentSetupFrame(Frame):
     def callback(self, selection):
         self.selected = selection
         return self.selected
-
-
-    def get_experiment_name(self):
-        return self.name_text.get('1.0', 'end')
-
-
-    def get_investigators(self):
-        if (self.selected != '' and self.selected not in self.invest_added):
-            self.invest_added.append(self.selected)
-        # TO-DO : add GUI to show who they've added
-        #         give option to remove added name?
-        return self.invest_added
-
-
-    def get_species(self):
-        return self.spec_text.get('1.0', 'end')
-
-
-    def add_items(self):
-        return
-        # TO-DO : add items list 
-        #         comma seperated or type one and hit add
-        #         display on gui?
-
-
-
-
-
-###############################################################
-# for demo purposes - remove once everything is all connected #
-
-if __name__ == '__main__':
-    root = Tk()
-    root.title("Mouser")
-    root.geometry('600x600')
-
-    main_frame = ExperimentSetupFrame(root, "Main")
-    frame = ExperimentSetupFrame(root, main_frame)
-    frame.raise_frame()
-
-    root.mainloop()
-###############################################################

--- a/GroupOrganizationFrame.py
+++ b/GroupOrganizationFrame.py
@@ -1,0 +1,39 @@
+from tkinter import *
+from tkinter.ttk import *
+from NavigateButton import *
+from CageSetupFrame import CageSetupFrame
+
+groups = {'group 1', 'group 2', 'group 3'}
+
+class GroupOrganizationFrame(Frame):
+    def __init__(self, parent: Tk, prev_page: Frame = None):
+        super().__init__(parent)
+
+        self.root = parent
+        self.pad_x = 10
+        self.pad_y = 20
+        self.label_font = ("Arial", 13)
+
+        self.grid(row=4, column=6, sticky='NESW')
+
+        title_label = Label(self, text='Experiment Setup', font=("Arial", 25))
+        title_label.grid(row=0, column=1, columnspan=3, padx=self.pad_x, pady=self.pad_y)
+
+        prev_button = NavigateButton(self, 'Previous', prev_page)
+        next_button = Button(self, text='Next', width=15, command=lambda: self.create_next(self))
+        prev_button.grid(row=4, column=0, columnspan=1, padx=self.pad_x, pady=self.pad_y, sticky=W)
+        next_button.grid(row=4, column=5, columnspan=1, padx=self.pad_x, pady=self.pad_y, sticky=E)
+        
+
+
+    def raise_frame(frame: Frame):
+        frame.tkraise()
+
+    def create_next(self, frame: Frame):
+        next = CageSetupFrame(self.root, frame)
+        next.grid(row=0, column=0)
+
+    def drag_group(self, groups):
+        for i in groups:
+            Label()
+

--- a/GroupSetupFrame.py
+++ b/GroupSetupFrame.py
@@ -1,18 +1,15 @@
-from operator import ne
 from tkinter import *
 from tkinter.ttk import *
+from NavigateButton import *
+from ScrollableFrame import *
+from GroupOrganizationFrame import *
 
-from NavigateButton import NavigateButton
-from ScrollableFrame import ScrollableFrame
-
-class GroupSetupPage(Frame):
-    def __init__(self, parent: Tk, prev_page: Frame = None, next_page: Frame = None):
+class GroupSetupFrame(Frame):
+    def __init__(self, parent: Tk, prev_page: Frame = None):
         super().__init__(parent)
-        self.prev_page = prev_page
-        self.next_page = next_page
 
+        self.root = parent
         self.group_names = []
-
         self.pad_x = 10
         self.pad_y = 20
         self.label_font = ("Arial", 13)
@@ -38,17 +35,18 @@ class GroupSetupPage(Frame):
         set_button = Button(self, text='Set', width=15, command=lambda: self.create_groups(int(group_num.get())))
         set_button.grid(row=1, column=4, padx=self.pad_x, pady=self.pad_y)
 
-        prev_button = NavigateButton(self, 'Previous', self.prev_page)
-        next_button = NavigateButton(self, 'Next', self.next_page)
+        prev_button = NavigateButton(self, 'Previous', prev_page)
+        next_button = Button(self, text='Next', width=15, command=lambda: self.create_next(self))
         prev_button.grid(row=4, column=0, columnspan=2, padx=self.pad_x, pady=self.pad_y, sticky=W)
         next_button.grid(row=4, column=3, columnspan=2, padx=self.pad_x, pady=self.pad_y)
-
-
 
 
     def raise_frame(frame: Frame):
         frame.tkraise()
 
+    def create_next(self, frame: Frame):
+        next = GroupOrganizationFrame(self.root, frame)
+        next.grid(row=0, column=0)
 
     def create_groups(self, num: int):
         scroll_frame = ScrollableFrame(self, num)
@@ -82,20 +80,3 @@ class GroupSetupPage(Frame):
         #   disable text fields, set button, save button
         return
 
-
-
-
-###############################################################
-# for demo purposes - remove once everything is all connected #
-
-if __name__ == '__main__':
-    root = Tk()
-    root.title("Mouser")
-    root.geometry('600x600')
-
-    main_frame = GroupSetupPage(root, "Main").grid(sticky=E)
-    frame = GroupSetupPage(root, main_frame)
-    frame.raise_frame()
-
-    root.mainloop()
-###############################################################

--- a/IdSetupFrame.py
+++ b/IdSetupFrame.py
@@ -1,14 +1,14 @@
 from tkinter import *
 from tkinter.ttk import *
-
 from NavigateButton import NavigateButton
+from GroupSetupFrame import *
 
 class IdSetupFrame(Frame):
-    def __init__(self, parent: Tk, prev_page: Frame = None, next_page: Frame = None):
+    def __init__(self, parent: Tk, prev_page: Frame = None):
         super().__init__(parent)
-        self.prev_page = prev_page
-        self.next_page = next_page
 
+        self.root = parent
+        
         # vars for input
         self.rfid = 0
         self.id = 0
@@ -54,8 +54,11 @@ class IdSetupFrame(Frame):
         # buttons
         add_button = Button(self, text='Add', width=15, command=lambda: self.add_id()).grid(row=2, column=3, padx=self.pad_x, pady=self.pad_y)
         sort_buton = Button(self, text='Sort by Weight', width=15, command=lambda: self.sort_table()).grid(row=4, column=3, padx=self.pad_x, pady=self.pad_y)
-        prev_button = NavigateButton(self, 'Previous', self.prev_page).grid(row=5, column=0, columnspan=2, padx=self.pad_x, pady=self.pad_y)
-        next_button = NavigateButton(self, 'Next', self.next_page).grid(row=5, column=3, columnspan=2, padx=self.pad_x, pady=self.pad_y)
+        
+        prev_button = NavigateButton(self, 'Previous', prev_page)
+        next_button = Button(self, text='Next', width=15, command=lambda: self.create_next(self))
+        prev_button.grid(row=5, column=0, columnspan=2, padx=self.pad_x, pady=self.pad_y)
+        next_button.grid(row=5, column=3, columnspan=2, padx=self.pad_x, pady=self.pad_y)
 
 
         for i in range (0,5):
@@ -70,14 +73,16 @@ class IdSetupFrame(Frame):
     def raise_frame(frame: Frame):
         frame.tkraise()
 
+    def create_next(self, frame: Frame):
+        next = GroupSetupFrame(self.root, frame)
+        next.grid(row=0, column=0)
 
-    # TO-DO : connect to data & add
     def add_id():
+        # TO-DO : connect to data & add
         return
 
-
-    # TO-DO : connect to data
     def create_table(self, ids):
+        # TO-DO : connect to data
         table = LabelFrame(self, height=200, width=(600 - self.pad_x*2), relief=RIDGE)
         table.grid(row=len(ids)+1, column=4)
 
@@ -95,26 +100,7 @@ class IdSetupFrame(Frame):
 
         return table
 
-
-    # TO-DO : connect to data and sort
     def sort_table(self, data):
+        # TO-DO : connect to data and sort
         # call create_table again with new sorted array of data
         return 
-
-
-
-
-###############################################################
-# for demo purposes - remove once everything is all connected #
-
-if __name__ == '__main__':
-    root = Tk()
-    root.title("Mouser")
-    root.geometry('600x600')
-
-    main_frame = IdSetupFrame(root, "Main").grid(sticky=E)
-    frame = IdSetupFrame(root, main_frame)
-    frame.raise_frame()
-
-    root.mainloop()
-###############################################################

--- a/NavigateButton.py
+++ b/NavigateButton.py
@@ -4,8 +4,8 @@ from tkinter.ttk import *
 class NavigateButton(Button):
     def __init__(self, page: Frame, name: str, nextPage: Frame):
         super().__init__(page, text=name, compound=TOP,
-                         width=15, command=lambda: self.navigate())
+                         width=15, command=lambda: self.navigate(nextPage))
         self.nextPage = nextPage
 
-    def navigate(self):
-        self.nextPage.tkraise()
+    def navigate(self, frame):
+        frame.tkraise()

--- a/main.py
+++ b/main.py
@@ -3,16 +3,17 @@ from tkinter.ttk import *
 from turtle import onclick
 from tk_models import *
 from accounts import AccountsFrame
+from ExperimentSetupFrame import *
 
 root = Tk()
 root.title("Mouser")
 root.geometry('600x600')
 
-animal_setup_frame = Frame(root)
 data_collection_frame = Frame(root)
 analysis_frame = Frame(root)
 main_frame = MouserPage(root, "Mouser")
 accounts_frame = AccountsFrame(root, main_frame)
+animal_setup_frame = ExperimentSetupFrame(root, main_frame)
 
 mouse_image = PhotoImage(file="./images/mouse_small.png")
 graph_image = PhotoImage(file="./images/graph_small.png")
@@ -32,7 +33,8 @@ frames = [animal_setup_frame,
           data_collection_frame, analysis_frame]
 
 for i, frame in enumerate(frames):
-    back = BackButton(frame, main_frame)
+    if frame != animal_setup_frame:
+        back = BackButton(frame, main_frame)
     frame.grid(row=0, column=0, sticky="NESW")
     frame.grid_rowconfigure(0, weight=1)
     frame.grid_columnconfigure(0, weight=1)
@@ -42,3 +44,4 @@ root.grid_rowconfigure(0, weight=1)
 root.grid_columnconfigure(0, weight=1)
 
 root.mainloop()
+


### PR DESCRIPTION
**What was changed?**
- Main.py: I added the animal setup frame (ExperimentSetupFrame) and removed the back button from said frame.
- All previously made Experiment Setup frames were modified by removing the 'next page' parameter. They instead initialize the next page in a function of the frame's class and navigate to said next page via the Next button. Back buttons are also functional leading to the previous page in the sequence. 
- ExperimentSetupFrame.py: fixed leftover camel case variables. 
- CageSetupFrame.py: created cage setup frame

**Why was it changed?**
- main.py did not yet have the experiment setup series added, now user can navigate through the experiment setup pages from the homepage of our app. Back button was placed on the Experiment Setup frame instead in order to keep consistent with the layout of the following pages.
- The Frame classes' 'next page' parameter made it difficult to initialize pages and point to frames that were not made yet. Moving the next page initialization made for a much easier transition between frames.

**Demonstration of Cage Setup Frame**
![CageSetupFrame](https://user-images.githubusercontent.com/102837772/197449094-2dfe9919-75ca-41a0-a55f-d0f4f75a6ab1.png)
