### PR TITLE
Previous and Next Buttons

### DIFF
--- a/accounts.py
+++ b/accounts.py
@@ -26,7 +26,7 @@ roles = ["generic", "admin"]
 
 class ConfigureUsersFrame(MouserPage):
     def __init__(self, parent: Tk, previous_page: Frame):
-        super().__init__(parent, "User Configuration", True, previous_page)
+        super().__init__(parent, "User Configuration", previous_page)
 
         Label(self, text="Email:").place(
             relx=0.12, rely=0.30)
@@ -115,17 +115,17 @@ class ConfigureUsersFrame(MouserPage):
 
 class ChangePasswordFrame(MouserPage):
     def __init__(self, parent: Tk, previous_page: Frame):
-        super().__init__(parent, "Change Password", True, previous_page)
+        super().__init__(parent, "Change Password", previous_page)
 
 
 class ConfigureOrganizationFrame(MouserPage):
     def __init__(self, parent: Tk, previous_page: Frame):
-        super().__init__(parent, "Organization Configuration", True, previous_page)
+        super().__init__(parent, "Organization Configuration", previous_page)
 
 
 class AccountsFrame(MouserPage):
     def __init__(self, parent: Tk, previous_page: Frame):
-        super().__init__(parent, "Accounts", True, previous_page)
+        super().__init__(parent, "Accounts", previous_page)
 
         gears_image = PhotoImage(file="./images/gears.png")
         user_settings_frame = ConfigureUsersFrame(parent, self)

--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ root.geometry('600x600')
 
 main_frame = MouserPage(root, "Mouser")
 
-animal_setup_frame = ExperimentSetupFrame(root)
 data_collection_frame = MouserPage(root, "Data Collection")
 analysis_frame = MouserPage(root, "Analysis")
 accounts_frame = AccountsFrame(root, main_frame)

--- a/main.py
+++ b/main.py
@@ -2,16 +2,23 @@ from tkinter import *
 from tkinter.ttk import *
 from turtle import onclick
 from tk_models import *
+
 from accounts import AccountsFrame
 from ExperimentSetupFrame import *
+
+from ExperimentSetupFrame import *
+from IdSetupFrame import *
+from GroupSetupFrame import *
 
 root = Tk()
 root.title("Mouser")
 root.geometry('600x600')
 
-data_collection_frame = Frame(root)
-analysis_frame = Frame(root)
 main_frame = MouserPage(root, "Mouser")
+
+animal_setup_frame = ExperimentSetupFrame(root)
+data_collection_frame = MouserPage(root, "Data Collection")
+analysis_frame = MouserPage(root, "Analysis")
 accounts_frame = AccountsFrame(root, main_frame)
 animal_setup_frame = ExperimentSetupFrame(root, main_frame)
 
@@ -33,8 +40,7 @@ frames = [animal_setup_frame,
           data_collection_frame, analysis_frame]
 
 for i, frame in enumerate(frames):
-    if frame != animal_setup_frame:
-        back = BackButton(frame, main_frame)
+    back = MenuButton(frame, main_frame)
     frame.grid(row=0, column=0, sticky="NESW")
     frame.grid_rowconfigure(0, weight=1)
     frame.grid_columnconfigure(0, weight=1)
@@ -44,4 +50,3 @@ root.grid_rowconfigure(0, weight=1)
 root.grid_columnconfigure(0, weight=1)
 
 root.mainloop()
-

--- a/tk_models.py
+++ b/tk_models.py
@@ -15,7 +15,7 @@ def create_nav_button(parent: Frame, name: str, button_image: PhotoImage, frame:
 
 class BackButton(Button):
     def __init__(self, page: Frame, previous_page: Frame):
-        super().__init__(page, text="Back", compound=TOP,
+        super().__init__(page, text="Back to Menu", compound=TOP,
                          width=15, command=lambda: self.navigate())
         self.place(relx=0.15, rely=0.10, anchor=CENTER)
         self.previous_page = previous_page
@@ -27,13 +27,13 @@ class BackButton(Button):
 class ChangePageButton(Button):
     def __init__(self, page: Frame, next_page: Frame, previous: bool = True):
         text = "Next"
-        x = 0.85
+        x = 0.75
         if previous:
             text = "Previous"
-            x = 0.15
+            x = 0.25
         super().__init__(page, text=text, compound=TOP,
                          width=15, command=lambda: self.navigate())
-        self.place(relx=x, rely=0.05, anchor=CENTER)
+        self.place(relx=x, rely=0.85, anchor=CENTER)
         self.next_page = next_page
 
     def navigate(self):
@@ -41,11 +41,11 @@ class ChangePageButton(Button):
 
 
 class MouserPage(Frame):
-    def __init__(self, parent: Tk, title: str, back_button: bool = False, previous_page: Frame = None, font=("Arial", 25)):
+    def __init__(self, parent: Tk, title: str, back_button: bool = False, previous_page: Frame = None):
         super().__init__(parent)
         self.title = title
-        title_label = Label(self, text=title, font=font)
-        title_label.grid(row=0, column=0, columnspan=4, sticky=N)
+        titleLabel = Label(self, text=title, font=("Arial", 25))
+        titleLabel.grid(row=0, column=0, columnspan=4, sticky=N)
         self.grid(row=0, column=0, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
@@ -66,6 +66,8 @@ if __name__ == '__main__':
     main_frame = MouserPage(root, "Main")
     frame = MouserPage(root, "Template", True, main_frame)
     frame.raiseFrame()
+
+    prev = ChangePageButton(main_frame, frame, False)
 
     root.grid_rowconfigure(0, weight=1)
     root.grid_columnconfigure(0, weight=1)

--- a/tk_models.py
+++ b/tk_models.py
@@ -24,6 +24,22 @@ class BackButton(Button):
         self.previous_page.tkraise()
 
 
+class ChangePageButton(Button):
+    def __init__(self, page: Frame, next_page: Frame, previous: bool = True):
+        text = "Next"
+        x = 0.85
+        if previous:
+            text = "Previous"
+            x = 0.15
+        super().__init__(page, text=text, compound=TOP,
+                         width=15, command=lambda: self.navigate())
+        self.place(relx=x, rely=0.05, anchor=CENTER)
+        self.next_page = next_page
+
+    def navigate(self):
+        self.next_page.tkraise()
+
+
 class MouserPage(Frame):
     def __init__(self, parent: Tk, title: str, back_button: bool = False, previous_page: Frame = None, font=("Arial", 25)):
         super().__init__(parent)

--- a/tk_models.py
+++ b/tk_models.py
@@ -13,7 +13,7 @@ def create_nav_button(parent: Frame, name: str, button_image: PhotoImage, frame:
     button.image = button_image
 
 
-class BackButton(Button):
+class MenuButton(Button):
     def __init__(self, page: Frame, previous_page: Frame):
         super().__init__(page, text="Back to Menu", compound=TOP,
                          width=15, command=lambda: self.navigate())
@@ -41,7 +41,7 @@ class ChangePageButton(Button):
 
 
 class MouserPage(Frame):
-    def __init__(self, parent: Tk, title: str, back_button: bool = False, previous_page: Frame = None):
+    def __init__(self, parent: Tk, title: str, menu_button: bool = False, menu_page: Frame = None):
         super().__init__(parent)
         self.title = title
         titleLabel = Label(self, text=title, font=("Arial", 25))
@@ -49,13 +49,27 @@ class MouserPage(Frame):
         self.grid(row=0, column=0, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
-        if (back_button):
-            self.back_button = BackButton(self, previous_page)
-        else:
-            self.back_button = None
+        self.menu_button = MenuButton(self, menu_page) if menu_button else None
+        self.next_button = None
+        self.previous_button = None
 
-    def raiseFrame(self):
+    def raise_frame(self):
         self.tkraise()
+
+    def set_next_button(self, next_page):
+        if self.next_button:
+            self.next_button.destroy()
+        self.next_button = ChangePageButton(self, next_page, False)
+
+    def set_previous_button(self, previous_page):
+        if self.previous_button:
+            self.previous_button.destroy()
+        self.previous_button = ChangePageButton(self, previous_page)
+
+    def set_menu_button(self, menu_page):
+        if self.menu_button:
+            self.menu_button.destroy()
+        self.menu_button = MenuButton(self, menu_page, False)
 
 
 if __name__ == '__main__':
@@ -64,10 +78,12 @@ if __name__ == '__main__':
     root.geometry('600x600')
 
     main_frame = MouserPage(root, "Main")
-    frame = MouserPage(root, "Template", True, main_frame)
-    frame.raiseFrame()
+    frame = MouserPage(root, "Template")
 
-    prev = ChangePageButton(main_frame, frame, False)
+    main_frame.set_next_button(frame)
+    frame.set_previous_button(main_frame)
+
+    main_frame.raise_frame()
 
     root.grid_rowconfigure(0, weight=1)
     root.grid_columnconfigure(0, weight=1)

--- a/tk_models.py
+++ b/tk_models.py
@@ -41,7 +41,7 @@ class ChangePageButton(Button):
 
 
 class MouserPage(Frame):
-    def __init__(self, parent: Tk, title: str, menu_button: bool = False, menu_page: Frame = None):
+    def __init__(self, parent: Tk, title: str, menu_page: Frame = None):
         super().__init__(parent)
         self.title = title
         titleLabel = Label(self, text=title, font=("Arial", 25))
@@ -49,7 +49,7 @@ class MouserPage(Frame):
         self.grid(row=0, column=0, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
-        self.menu_button = MenuButton(self, menu_page) if menu_button else None
+        self.menu_button = MenuButton(self, menu_page) if menu_page else None
         self.next_button = None
         self.previous_button = None
 


### PR DESCRIPTION
Closes #20

**What was changed?**
In our template for the application's pages, I added the option to include navigation buttons, which are shown as "next" and "previous".

**Why was it changed?**
These buttons were added so that it is easier for us to move between each of the pages of our application.

**How was it changed?**
In the file where we have all of our templated code (tk_models.py), I added buttons in our template page, where developers are given the option to add the navigation buttons if they want, but they aren't required to.

Screenshots:
![image](https://user-images.githubusercontent.com/57450075/197604067-92f733e5-3ed9-4c66-a038-c58b2515d6bc.png)
This shows what the "next" button looks like in the raw version of our page template.

![image](https://user-images.githubusercontent.com/57450075/197604316-ad3ff33a-1210-4119-83d5-36a7f2822259.png)
This is where the user goes when clicking on the "next" button from the first page. If you click on the "previous" button here, it leads you back to that first page.