### PR TITLE
Small Fixes to Experiment Setup

### DIFF
--- a/experiment_pages/experiment.py
+++ b/experiment_pages/experiment.py
@@ -57,10 +57,6 @@ class Experiment():
         return self.data_collect_type
 
 
-    def get_date_created(self):
-        return self.date_created
-
-
     def save_to_database(self):
         db = ExperimentDatabase()
         db.setup_experiment(self.name, self.species, self.rfid, self.num_animals, 

--- a/experiment_pages/experiment.py
+++ b/experiment_pages/experiment.py
@@ -1,4 +1,5 @@
 from ExperimentDatabase import ExperimentDatabase
+from datetime import date
 
 class Experiment():
     def __init__(self):
@@ -14,7 +15,7 @@ class Experiment():
         self.animals_per_group = ''
         self.group_names = []
         self.data_collect_type = []
-
+        self.date_created = str(date.today())
 
     def get_name(self):
         return self.name
@@ -56,11 +57,17 @@ class Experiment():
         return self.data_collect_type
 
 
+    def get_date_created(self):
+        return self.date_created
+
+
     def save_to_database(self):
         db = ExperimentDatabase()
         db.setup_experiment(self.name, self.species, self.rfid, self.num_animals, 
                             self.num_groups, self.max_per_cage)
         db.setup_groups(self.group_names, self.animals_per_group)
         db.setup_measurement_items(self.data_collect_type)
+        
+        # TO:DO save date created to db
 
         

--- a/experiment_pages/group_config_ui.py
+++ b/experiment_pages/group_config_ui.py
@@ -9,7 +9,6 @@ class GroupConfigUI(MouserPage):
         super().__init__(parent, "New Experiment - Group Configuration", prev_page)
 
         self.input = input
-        self.prev_page = prev_page
 
         self.next_page = SummaryUI(self.input, parent, self, menu_page)
         self.set_next_button(self.next_page)
@@ -67,7 +66,6 @@ class GroupConfigUI(MouserPage):
             self.item_man_buttons.append(man)
 
 
-
     def update_page(self):
         for widget in self.group_frame.winfo_children():
             widget.destroy()
@@ -75,11 +73,6 @@ class GroupConfigUI(MouserPage):
             widget.destroy()
         self.create_group_entries(int(self.input.get_num_groups()))
         self.create_item_frame(self.input.get_measurement_items())
-
-
-    def destroy(self) -> None:
-        self.prev_page.destroy()
-        return super().destroy()
 
 
     def save_input(self):

--- a/experiment_pages/group_config_ui.py
+++ b/experiment_pages/group_config_ui.py
@@ -9,6 +9,7 @@ class GroupConfigUI(MouserPage):
         super().__init__(parent, "New Experiment - Group Configuration", prev_page)
 
         self.input = input
+        self.prev_page = prev_page
 
         self.next_page = SummaryUI(self.input, parent, self, menu_page)
         self.set_next_button(self.next_page)
@@ -74,6 +75,11 @@ class GroupConfigUI(MouserPage):
             widget.destroy()
         self.create_group_entries(int(self.input.get_num_groups()))
         self.create_item_frame(self.input.get_measurement_items())
+
+
+    def destroy(self) -> None:
+        self.prev_page.destroy()
+        return super().destroy()
 
 
     def save_input(self):

--- a/experiment_pages/select_experiment_ui.py
+++ b/experiment_pages/select_experiment_ui.py
@@ -31,14 +31,20 @@ class ExperimentsUI(MouserPage):
         new_exp_frame = NewExperimentUI(parent, self)
         NewExperimentButton(self, new_exp_frame)
 
-        Label(self, text='Name').place(relx=0.14, rely=0.2)
-        Label(self, text='Date Created').place(relx=0.7, rely=0.2)
-
         self.main_frame = Frame(self, width=500)
         self.main_frame.grid(row=1, column=1, sticky='NESW')
         self.main_frame.place(relx=0.12, rely=0.25)
 
         self.selectable_frames = []
+        self.update_frame()
+
+
+    def update_frame(self):
+        for widget in self.main_frame.winfo_children():
+            widget.destroy()
+
+        Label(self, text='Name').place(relx=0.14, rely=0.2)
+        Label(self, text='Date Created').place(relx=0.7, rely=0.2)
 
         index = 0
         for exp in experiment_list:
@@ -73,3 +79,4 @@ class ExperimentsUI(MouserPage):
     def frame_click(self, event, experiment):
         page = ExperimentMenuUI(self.parent, experiment, self)
         page.tkraise()
+

--- a/experiment_pages/select_experiment_ui.py
+++ b/experiment_pages/select_experiment_ui.py
@@ -13,11 +13,15 @@ experiment_list = {
 
 
 class NewExperimentButton(Button):
-    def __init__(self, page: Frame, next_page: Frame):
+    def __init__(self, parent: Tk, page: Frame):
         super().__init__(page, text="Create New Experiment", compound=TOP,
-                         width=22, command=lambda: self.navigate())
+                         width=22, command=lambda: [self.create_next_page(), self.navigate()])
         self.place(relx=0.85, rely=0.15, anchor=CENTER)
-        self.next_page = next_page
+        self.parent = parent
+        self.page = page
+
+    def create_next_page(self):
+        self.next_page = NewExperimentUI(self.parent, self.page)
 
     def navigate(self):
         self.next_page.tkraise()
@@ -28,8 +32,7 @@ class ExperimentsUI(MouserPage):
         super().__init__(parent, "Experiments", prev_page)
         self.parent = parent
 
-        new_exp_frame = NewExperimentUI(parent, self)
-        NewExperimentButton(self, new_exp_frame)
+        NewExperimentButton(parent, self)
 
         self.main_frame = Frame(self, width=500)
         self.main_frame.grid(row=1, column=1, sticky='NESW')

--- a/experiment_pages/summary_ui.py
+++ b/experiment_pages/summary_ui.py
@@ -20,6 +20,7 @@ class SummaryUI(MouserPage):
         super().__init__(parent, "New Experiment - Summary", prev_page)
         
         self.input = input
+        self.prev_page = prev_page
 
         CreateExperimentButton(input, self, menu_page)
 
@@ -74,4 +75,5 @@ class SummaryUI(MouserPage):
 
     def create_experiment(self):
         self.input.save_to_database()
+        self.prev_page.destroy()
 

--- a/experiment_pages/summary_ui.py
+++ b/experiment_pages/summary_ui.py
@@ -75,5 +75,4 @@ class SummaryUI(MouserPage):
 
     def create_experiment(self):
         self.input.save_to_database()
-        self.prev_page.destroy()
 

--- a/experiment_pages/summary_ui.py
+++ b/experiment_pages/summary_ui.py
@@ -7,7 +7,7 @@ from experiment_pages.experiment import Experiment
 class CreateExperimentButton(Button):
     def __init__(self, experiment: Experiment, page: Frame, menu_page: Frame):
         super().__init__(page, text="Create", compound=TOP,
-                         width=15, command=lambda: [experiment.save_to_database(), self.navigate()])
+                         width=15, command=lambda: [menu_page.update_frame(), experiment.save_to_database(), self.navigate()])
         self.place(relx=0.85, rely=0.15, anchor=CENTER)
         self.next_page = menu_page
 
@@ -35,7 +35,6 @@ class SummaryUI(MouserPage):
         for widget in self.group_frame.winfo_children():
             widget.destroy()
         self.create_summary_frame() 
-        
 
 
     def create_summary_frame(self):


### PR DESCRIPTION
### What Was Changed
experiment.py was modified to store the date experiment was created (this still needs to be passed to the database).

experiment_selection was modified to initialize the NewExperimentUI object on "create" button press rather than ExperimentsUI initialization in order to have a new object made upon a second/new create experiment creation sequence.
- this was necessary as before changes the user's input did not reset after finishing one experiment creation and then beginning to create a second experiment file. The experiment would then be overwriting the previous data in the database as well rather than creating a new entry.

summary_ui,py was modified to call the ExperimentsUI to update the frame. 
- when this object is connected to the database, we will pull all experiments and the page will update to display the newly created experiment in the selection menu.