### PR TITLE
Main Window of App Resizable

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from experiment_pages.select_experiment_ui import ExperimentsUI
 root = Tk()
 root.title("Mouser")
 root.geometry('600x600')
-root.resizable(False, False)
+root.minsize(600,600)
 
 main_frame = MouserPage(root, "Mouser")
 login_frame = LoginFrame(root, main_frame)

--- a/tk_models.py
+++ b/tk_models.py
@@ -48,8 +48,8 @@ class MouserPage(Frame):
         self.canvas = Canvas(self, width=600, height=600)
         self.canvas.grid(row=0, column=0, columnspan=4)
         self.rectangle = self.canvas.create_rectangle(0, 0, 600, 50, fill='#0097A7')
-        titleLabel = self.canvas.create_text(300, 13, anchor="n")
-        self.canvas.itemconfig(titleLabel, text=title, font=("Arial", 18))
+        self.title_label = self.canvas.create_text(300, 13, anchor="n")
+        self.canvas.itemconfig(self.title_label, text=title, font=("Arial", 18))
 
         self.grid(row=0, column=0, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)
@@ -80,21 +80,23 @@ class MouserPage(Frame):
 
     def check_window_size(self):
         root = self.winfo_toplevel()
-        if root.winfo_width() > self.canvas.winfo_width():
-            self.resize_canvas_width(root.winfo_width())
-        if root.winfo_height() > self.canvas.winfo_height():
+        if root.winfo_height() != self.canvas.winfo_height():
             self.resize_canvas_height(root.winfo_height())
+        if root.winfo_width() != self.canvas.winfo_width():
+            self.resize_canvas_width(root.winfo_width())
 
         self.after(10, self.check_window_size)
+
+    def resize_canvas_height(self, root_height):
+        self.canvas.config(height=root_height)
 
     def resize_canvas_width(self, root_width):
         self.canvas.config(width=root_width)
 
         x0, y0, x1, y2 = self.canvas.coords(self.rectangle)
+        x3, y3 = self.canvas.coords(self.title_label)
         self.canvas.coords(self.rectangle, x0, y0, root_width, y2)
-
-    def resize_canvas_height(self, root_height):
-        self.canvas.config(height=root_height)
+        self.canvas.coords(self.title_label, (root_width/2), y3)
 
 
 

--- a/tk_models.py
+++ b/tk_models.py
@@ -45,11 +45,11 @@ class MouserPage(Frame):
         super().__init__(parent)
         self.title = title
 
-        canvas = Canvas(self, width=600, height=600)
-        canvas.grid(row=0, column=0, columnspan=4)
-        rectangle = canvas.create_rectangle(0, 0, 600, 50, fill='#0097A7')
-        titleLabel = canvas.create_text(300, 13, anchor="n")
-        canvas.itemconfig(titleLabel, text=title, font=("Arial", 18))
+        self.canvas = Canvas(self, width=600, height=600)
+        self.canvas.grid(row=0, column=0, columnspan=4)
+        self.rectangle = self.canvas.create_rectangle(0, 0, 600, 50, fill='#0097A7')
+        titleLabel = self.canvas.create_text(300, 13, anchor="n")
+        self.canvas.itemconfig(titleLabel, text=title, font=("Arial", 18))
 
         self.grid(row=0, column=0, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)
@@ -57,6 +57,8 @@ class MouserPage(Frame):
         self.menu_button = MenuButton(self, menu_page) if menu_page else None
         self.next_button = None
         self.previous_button = None
+
+        self.check_window_size()
 
     def raise_frame(self):
         self.tkraise()
@@ -75,6 +77,25 @@ class MouserPage(Frame):
         if self.menu_button:
             self.menu_button.destroy()
         self.menu_button = MenuButton(self, menu_page, False)
+
+    def check_window_size(self):
+        root = self.winfo_toplevel()
+        if root.winfo_width() > self.canvas.winfo_width():
+            self.resize_canvas_width(root.winfo_width())
+        if root.winfo_height() > self.canvas.winfo_height():
+            self.resize_canvas_height(root.winfo_height())
+
+        self.after(10, self.check_window_size)
+
+    def resize_canvas_width(self, root_width):
+        self.canvas.config(width=root_width)
+
+        x0, y0, x1, y2 = self.canvas.coords(self.rectangle)
+        self.canvas.coords(self.rectangle, x0, y0, root_width, y2)
+
+    def resize_canvas_height(self, root_height):
+        self.canvas.config(height=root_height)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What was Changed?**
The app's root window was modified to allow resizing with the restraint of the minimum size being equal to the default window size given.
Tk_models was given functions to resize both the Canvas that serves as the backdrop of the application window as well as the title banner that appears atop each page.

 **Why was this Changed?**
The app was not previously able to be resized at all or allowed to be made full-screen. This resize functionality will help better the user experience of the app as well as allow pages to display more necessary information at a time.

**Next Steps:**
Some individual pages will need to be modified to better display information and reflect this change.

**Screenshots:**
Before:
![Screenshot_20230214_084725](https://user-images.githubusercontent.com/102837772/218914596-dd8b4ce2-4464-4e6b-9c8f-540bb5a909c7.png)

After:
![Screenshot_20230214_084742](https://user-images.githubusercontent.com/102837772/218914646-07fb02a3-febe-44e8-a66b-05675015c02e.png)
