### PR TITLE
Horzontal scroll/resize

### DIFF
--- a/experiment_pages/cage_config_ui.py
+++ b/experiment_pages/cage_config_ui.py
@@ -1,7 +1,7 @@
 from tkinter import *
 from tkinter.ttk import *
 from tk_models import *
-from scrollable_frame import VerticalScrolledFrame
+from scrollable_frame import ScrolledFrame
 from ExperimentDatabase import ExperimentDatabase
 
 
@@ -18,7 +18,7 @@ class CageConfigurationUI(MouserPage):
         self.ipad = 2
         self.pad = 5
 
-        scroll_canvas = VerticalScrolledFrame(self, width=550, height=400)
+        scroll_canvas = ScrolledFrame(self, width=550, height=400)
         scroll_canvas.place(relx=0.05, rely=0.20)
 
         self.main_frame = Frame(scroll_canvas)

--- a/experiment_pages/cage_config_ui.py
+++ b/experiment_pages/cage_config_ui.py
@@ -12,14 +12,13 @@ class CageConfigurationUI(MouserPage):
         file = str(database) + '.db'
         self.db = ExperimentDatabase(file)
 
-
         # unchanging data for stuff:
         self.groups = self.db.get_all_groups()
         self.ipad = 2
         self.pad = 5
 
-        scroll_canvas = ScrolledFrame(self, width=550, height=400)
-        scroll_canvas.place(relx=0.05, rely=0.20)
+        scroll_canvas = ScrolledFrame(self)
+        scroll_canvas.place(relx=0.05, rely=0.20, relheight=0.75, relwidth=0.88)
 
         self.main_frame = Frame(scroll_canvas)
         self.main_frame.grid(row=2, column=3, sticky='NESW')
@@ -80,7 +79,6 @@ class CageConfigurationUI(MouserPage):
                     j += 1
 
             self.group_frames.append(frame)            
-
 
 
 

--- a/experiment_pages/group_config_ui.py
+++ b/experiment_pages/group_config_ui.py
@@ -1,7 +1,7 @@
 from tkinter import *
 from tkinter.ttk import *
 from tk_models import *
-from scrollable_frame import VerticalScrolledFrame
+from scrollable_frame import ScrolledFrame
 from experiment_pages.summary_ui import SummaryUI
 from experiment_pages.experiment import Experiment
 
@@ -14,7 +14,7 @@ class GroupConfigUI(MouserPage):
         self.next_page = SummaryUI(self.input, parent, self, menu_page)
         self.set_next_button(self.next_page)
 
-        scroll_canvas = VerticalScrolledFrame(self, width=410, height=400)
+        scroll_canvas = ScrolledFrame(self, width=410, height=400)
         scroll_canvas.place(relx=0.27, rely=0.25)
 
         self.main_frame = Frame(scroll_canvas)

--- a/experiment_pages/group_config_ui.py
+++ b/experiment_pages/group_config_ui.py
@@ -14,11 +14,11 @@ class GroupConfigUI(MouserPage):
         self.next_page = SummaryUI(self.input, parent, self, menu_page)
         self.set_next_button(self.next_page)
 
-        scroll_canvas = ScrolledFrame(self, width=410, height=400)
-        scroll_canvas.place(relx=0.27, rely=0.25)
+        scroll_canvas = ScrolledFrame(self)
+        scroll_canvas.place(relx=0.1, rely=0.25, relheight=0.75, relwidth=0.88)
 
         self.main_frame = Frame(scroll_canvas)
-        self.main_frame.grid(row=2, column=1, sticky='NESW')
+        self.main_frame.grid(row=0, column=0, sticky='NESW')
 
         self.group_frame = Frame(self.main_frame)
         self.item_frame = Frame(self.main_frame)
@@ -46,7 +46,7 @@ class GroupConfigUI(MouserPage):
         Label(self.group_frame, text="Group Name").grid(row=0, column=0, padx=10, pady=10)
         self.group_input = []
         for i in range(0, num):
-            name = Entry(self.group_frame, width = 40)
+            name = Entry(self.group_frame, width = 60)
             name.grid(row=i+1, column=0, padx=10, pady=10)
             self.group_input.append(name)
 

--- a/experiment_pages/new_experiment_ui.py
+++ b/experiment_pages/new_experiment_ui.py
@@ -19,7 +19,7 @@ class NewExperimentUI(MouserPage):
         self.set_next_button(self.next_page)
 
         scroll_canvas = ScrolledFrame(self, width=500, height=400)
-        scroll_canvas.place(relx=0.12, rely=0.25)
+        scroll_canvas.place(relx=0.12, rely=0.25, relheight=0.75, relwidth=0.88)
 
         self.main_frame = Frame(scroll_canvas)
         self.main_frame.grid(row=10, column=3, sticky='NESW')
@@ -80,8 +80,8 @@ class NewExperimentUI(MouserPage):
         
         for i in range(0,10):
             if i < 3:
-                self.grid_columnconfigure(i, weight=1)
-            self.grid_rowconfigure(i, weight=1)
+                self.main_frame.grid_columnconfigure(i, weight=1)
+            self.main_frame.grid_rowconfigure(i, weight=1)
 
 
     def set_next_button(self, next_page):

--- a/experiment_pages/new_experiment_ui.py
+++ b/experiment_pages/new_experiment_ui.py
@@ -1,7 +1,7 @@
 from tkinter import *
 from tkinter.ttk import *
 from tk_models import *
-from scrollable_frame import VerticalScrolledFrame
+from scrollable_frame import ScrolledFrame
 from experiment_pages.group_config_ui import GroupConfigUI
 from experiment_pages.experiment import Experiment
 from users_database import UsersDatabase
@@ -18,7 +18,7 @@ class NewExperimentUI(MouserPage):
         self.next_page = GroupConfigUI(self.input, parent, self, menu_page)
         self.set_next_button(self.next_page)
 
-        scroll_canvas = VerticalScrolledFrame(self, width=500, height=400)
+        scroll_canvas = ScrolledFrame(self, width=500, height=400)
         scroll_canvas.place(relx=0.12, rely=0.25)
 
         self.main_frame = Frame(scroll_canvas)

--- a/experiment_pages/new_experiment_ui.py
+++ b/experiment_pages/new_experiment_ui.py
@@ -18,7 +18,7 @@ class NewExperimentUI(MouserPage):
         self.next_page = GroupConfigUI(self.input, parent, self, menu_page)
         self.set_next_button(self.next_page)
 
-        scroll_canvas = ScrolledFrame(self, width=500, height=400)
+        scroll_canvas = ScrolledFrame(self)
         scroll_canvas.place(relx=0.12, rely=0.25, relheight=0.75, relwidth=0.88)
 
         self.main_frame = Frame(scroll_canvas)

--- a/experiment_pages/select_experiment_ui.py
+++ b/experiment_pages/select_experiment_ui.py
@@ -1,7 +1,7 @@
 from tkinter import *
 from tkinter.ttk import *
 from tk_models import *
-from scrollable_frame import VerticalScrolledFrame
+from scrollable_frame import ScrolledFrame
 import csv
 from experiment_pages.new_experiment_ui import NewExperimentUI
 from experiment_pages.experiment_menu_ui import ExperimentMenuUI
@@ -28,7 +28,7 @@ class ExperimentsUI(MouserPage):
 
         NewExperimentButton(parent, self)
 
-        scroll_canvas = VerticalScrolledFrame(self, width=500, height=400)
+        scroll_canvas = ScrolledFrame(self, width=500, height=400)
         scroll_canvas.place(relx=0.12, rely=0.25)
 
         self.main_frame = Frame(scroll_canvas, width=500)

--- a/experiment_pages/select_experiment_ui.py
+++ b/experiment_pages/select_experiment_ui.py
@@ -28,11 +28,14 @@ class ExperimentsUI(MouserPage):
 
         NewExperimentButton(parent, self)
 
-        scroll_canvas = ScrolledFrame(self, width=500, height=400)
-        scroll_canvas.place(relx=0.12, rely=0.25)
+        scroll_canvas = ScrolledFrame(self)
+        scroll_canvas.place(relx=0.12, rely=0.25, relheight=0.75, relwidth=0.88)
 
-        self.main_frame = Frame(scroll_canvas, width=500)
+        self.main_frame = Frame(scroll_canvas)
         self.main_frame.grid(row=1, column=1, sticky='NESW')
+
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
 
         self.selectable_frames = []
         self.update_frame()
@@ -62,10 +65,13 @@ class ExperimentsUI(MouserPage):
             date = exp[1]
             self.create_selectable_frame(name, date, index)
 
+            self.main_frame.grid_columnconfigure(index, weight=1)
+            self.main_frame.grid_rowconfigure(index, weight=1)
+
 
     def create_selectable_frame(self, name, date, index):
-        frame = Frame(self.main_frame, borderwidth=3, width=500, relief='groove')
-        frame.grid(row=index, column=0, pady=5)
+        frame = Frame(self.main_frame, borderwidth=3, relief='groove')
+        frame.grid(row=index, column=0, pady=5, sticky='NESW')
         name_label = Label(frame, text=name, width=30, font=("Arial", 12))
         name_label.grid(row=index, column=0, padx=20, sticky=W)
         date_label = Label(frame, text=date, font=("Arial", 12))

--- a/experiment_pages/summary_ui.py
+++ b/experiment_pages/summary_ui.py
@@ -1,7 +1,7 @@
 from tkinter import *
 from tkinter.ttk import *
 from tk_models import *
-from scrollable_frame import VerticalScrolledFrame
+from scrollable_frame import ScrolledFrame
 from experiment_pages.experiment import Experiment
 
 
@@ -25,7 +25,7 @@ class SummaryUI(MouserPage):
 
         CreateExperimentButton(input, self, menu_page)
 
-        scroll_canvas = VerticalScrolledFrame(self, width=390, height=400)
+        scroll_canvas = ScrolledFrame(self, width=390, height=400)
         scroll_canvas.place(relx=0.30, rely=0.25)
 
         self.main_frame = Frame(scroll_canvas)

--- a/experiment_pages/summary_ui.py
+++ b/experiment_pages/summary_ui.py
@@ -25,8 +25,8 @@ class SummaryUI(MouserPage):
 
         CreateExperimentButton(input, self, menu_page)
 
-        scroll_canvas = ScrolledFrame(self, width=390, height=400)
-        scroll_canvas.place(relx=0.30, rely=0.25)
+        scroll_canvas = ScrolledFrame(self)
+        scroll_canvas.place(relx=0.30, rely=0.25, relheight=0.7, relwidth=0.8)
 
         self.main_frame = Frame(scroll_canvas)
         self.main_frame.grid(row=8, column=1, sticky='NESW')

--- a/scrollable_frame.py
+++ b/scrollable_frame.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 
 
-class VerticalScrolledFrame:
+class ScrolledFrame:
     def __init__(self, master, **kwargs):
         width = kwargs.pop('width', None)
         height = kwargs.pop('height', None)
@@ -9,16 +9,21 @@ class VerticalScrolledFrame:
 
         self.outer_frame = tk.Frame(master, **kwargs)
 
-        self.scrollbar = tk.Scrollbar(self.outer_frame, orient=tk.VERTICAL)
-        self.scrollbar.pack(fill=tk.Y, side=tk.RIGHT)
+        self.vert_scrollbar = tk.Scrollbar(self.outer_frame, orient=tk.VERTICAL)
+        self.horz_scrollbar = tk.Scrollbar(self.outer_frame, orient=tk.HORIZONTAL)
+
+        self.vert_scrollbar.pack(fill=tk.Y, side=tk.RIGHT)
+        self.horz_scrollbar.pack(fill=tk.X, side=tk.BOTTOM)
 
         self.canvas = tk.Canvas(self.outer_frame, highlightthickness=0, width=width, height=height, bg=background)
         self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.canvas['yscrollcommand'] = self.scrollbar.set
+        self.canvas['yscrollcommand'] = self.vert_scrollbar.set
+        self.canvas['xscrollcommand'] = self.horz_scrollbar.set
         
         self.canvas.bind("<Enter>", self._bind_mouse)
         self.canvas.bind("<Leave>", self._unbind_mouse)
-        self.scrollbar['command'] = self.canvas.yview
+        self.vert_scrollbar['command'] = self.canvas.yview
+        self.horz_scrollbar['command'] = self.canvas.xview
 
         self.inner = tk.Frame(self.canvas, bg=background)
         
@@ -58,4 +63,29 @@ class VerticalScrolledFrame:
 
     def __str__(self):
         return str(self.outer_frame)
+
+
+    # code for main window resize from Mouser Page
+
+    # def check_window_size(self):
+    #     root = self.winfo_toplevel()
+    #     if root.winfo_height() != self.canvas.winfo_height():
+    #         self.resize_canvas_height(root.winfo_height())
+    #     if root.winfo_width() != self.canvas.winfo_width():
+    #         self.resize_canvas_width(root.winfo_width())
+
+    #     self.after(10, self.check_window_size)
+
+    # def resize_canvas_height(self, root_height):
+    #     self.canvas.config(height=root_height)
+
+    # def resize_canvas_width(self, root_width):
+    #     self.canvas.config(width=root_width)
+
+    #     x0, y0, x1, y2 = self.canvas.coords(self.rectangle)
+    #     x3, y3 = self.canvas.coords(self.title_label)
+    #     self.canvas.coords(self.rectangle, x0, y0, root_width, y2)
+    #     self.canvas.coords(self.title_label, (root_width/2), y3)
+
+
 

--- a/scrollable_frame.py
+++ b/scrollable_frame.py
@@ -3,12 +3,8 @@ from tkinter.ttk import *
 
 
 class ScrolledFrame:
-    def __init__(self, master, **kwargs):
-        width = kwargs.pop('width', None)
-        height = kwargs.pop('height', None)
-        background = kwargs.pop('bg', kwargs.pop('background', None))
-
-        self.outer_frame = Frame(master, **kwargs)
+    def __init__(self, master):
+        self.outer_frame = Frame(master)
 
         self.vert_scrollbar = Scrollbar(self.outer_frame, orient=VERTICAL)
         self.horz_scrollbar = Scrollbar(self.outer_frame, orient=HORIZONTAL)
@@ -16,7 +12,7 @@ class ScrolledFrame:
         self.vert_scrollbar.pack(fill=Y, side=RIGHT)
         self.horz_scrollbar.pack(fill=X, side=BOTTOM)
 
-        self.canvas = Canvas(self.outer_frame, highlightthickness=0, width=width, height=height, bg=background)
+        self.canvas = Canvas(self.outer_frame)
         self.canvas.pack(side=LEFT, fill=BOTH, expand=True)
         self.canvas['yscrollcommand'] = self.vert_scrollbar.set
         self.canvas['xscrollcommand'] = self.horz_scrollbar.set
@@ -26,12 +22,13 @@ class ScrolledFrame:
         self.vert_scrollbar['command'] = self.canvas.yview
         self.horz_scrollbar['command'] = self.canvas.xview
 
-        self.inner = Frame(self.canvas, bg=background)
+        self.inner = Frame(self.canvas)
         
         self.canvas.create_window(4, 4, window=self.inner, anchor='nw')
         self.inner.bind("<Configure>", self._on_frame_configure)
 
         self.outer_attr = set(dir(Widget))
+
 
     def __getattr__(self, item):
         if item in self.outer_attr:
@@ -44,8 +41,9 @@ class ScrolledFrame:
     def _on_frame_configure(self, event=None):
         x1, y1, x2, y2 = self.canvas.bbox("all")
         height = self.canvas.winfo_height()
-        self.canvas.config(scrollregion = (0,0, x2, max(y2, height)))
-
+        width = self.canvas.winfo_width()
+        self.canvas.config(scrollregion = (0,0, max(x2, width), max(y2, height)))
+        
     def _bind_mouse(self, event=None):
         self.canvas.bind_all("<4>", self._on_mousewheel)
         self.canvas.bind_all("<5>", self._on_mousewheel)
@@ -64,5 +62,4 @@ class ScrolledFrame:
 
     def __str__(self):
         return str(self.outer_frame)
-
 

--- a/scrollable_frame.py
+++ b/scrollable_frame.py
@@ -12,7 +12,7 @@ class ScrolledFrame:
         self.vert_scrollbar.pack(fill=Y, side=RIGHT)
         self.horz_scrollbar.pack(fill=X, side=BOTTOM)
 
-        self.canvas = Canvas(self.outer_frame)
+        self.canvas = Canvas(self.outer_frame, highlightthickness=0)
         self.canvas.pack(side=LEFT, fill=BOTH, expand=True)
         self.canvas['yscrollcommand'] = self.vert_scrollbar.set
         self.canvas['xscrollcommand'] = self.horz_scrollbar.set

--- a/scrollable_frame.py
+++ b/scrollable_frame.py
@@ -1,4 +1,5 @@
-import tkinter as tk
+from tkinter import *
+from tkinter.ttk import *
 
 
 class ScrolledFrame:
@@ -7,16 +8,16 @@ class ScrolledFrame:
         height = kwargs.pop('height', None)
         background = kwargs.pop('bg', kwargs.pop('background', None))
 
-        self.outer_frame = tk.Frame(master, **kwargs)
+        self.outer_frame = Frame(master, **kwargs)
 
-        self.vert_scrollbar = tk.Scrollbar(self.outer_frame, orient=tk.VERTICAL)
-        self.horz_scrollbar = tk.Scrollbar(self.outer_frame, orient=tk.HORIZONTAL)
+        self.vert_scrollbar = Scrollbar(self.outer_frame, orient=VERTICAL)
+        self.horz_scrollbar = Scrollbar(self.outer_frame, orient=HORIZONTAL)
 
-        self.vert_scrollbar.pack(fill=tk.Y, side=tk.RIGHT)
-        self.horz_scrollbar.pack(fill=tk.X, side=tk.BOTTOM)
+        self.vert_scrollbar.pack(fill=Y, side=RIGHT)
+        self.horz_scrollbar.pack(fill=X, side=BOTTOM)
 
-        self.canvas = tk.Canvas(self.outer_frame, highlightthickness=0, width=width, height=height, bg=background)
-        self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.canvas = Canvas(self.outer_frame, highlightthickness=0, width=width, height=height, bg=background)
+        self.canvas.pack(side=LEFT, fill=BOTH, expand=True)
         self.canvas['yscrollcommand'] = self.vert_scrollbar.set
         self.canvas['xscrollcommand'] = self.horz_scrollbar.set
         
@@ -25,12 +26,12 @@ class ScrolledFrame:
         self.vert_scrollbar['command'] = self.canvas.yview
         self.horz_scrollbar['command'] = self.canvas.xview
 
-        self.inner = tk.Frame(self.canvas, bg=background)
+        self.inner = Frame(self.canvas, bg=background)
         
         self.canvas.create_window(4, 4, window=self.inner, anchor='nw')
         self.inner.bind("<Configure>", self._on_frame_configure)
 
-        self.outer_attr = set(dir(tk.Widget))
+        self.outer_attr = set(dir(Widget))
 
     def __getattr__(self, item):
         if item in self.outer_attr:
@@ -63,4 +64,5 @@ class ScrolledFrame:
 
     def __str__(self):
         return str(self.outer_frame)
+
 

--- a/scrollable_frame.py
+++ b/scrollable_frame.py
@@ -64,28 +64,3 @@ class ScrolledFrame:
     def __str__(self):
         return str(self.outer_frame)
 
-
-    # code for main window resize from Mouser Page
-
-    # def check_window_size(self):
-    #     root = self.winfo_toplevel()
-    #     if root.winfo_height() != self.canvas.winfo_height():
-    #         self.resize_canvas_height(root.winfo_height())
-    #     if root.winfo_width() != self.canvas.winfo_width():
-    #         self.resize_canvas_width(root.winfo_width())
-
-    #     self.after(10, self.check_window_size)
-
-    # def resize_canvas_height(self, root_height):
-    #     self.canvas.config(height=root_height)
-
-    # def resize_canvas_width(self, root_width):
-    #     self.canvas.config(width=root_width)
-
-    #     x0, y0, x1, y2 = self.canvas.coords(self.rectangle)
-    #     x3, y3 = self.canvas.coords(self.title_label)
-    #     self.canvas.coords(self.rectangle, x0, y0, root_width, y2)
-    #     self.canvas.coords(self.title_label, (root_width/2), y3)
-
-
-

--- a/tk_models.py
+++ b/tk_models.py
@@ -45,9 +45,6 @@ class MouserPage(Frame):
         super().__init__(parent)
         self.title = title
 
-        style = Style()
-        style.configure("TFrame", background="green")
-
         self.canvas = Canvas(self, width=600, height=600)
         self.canvas.grid(row=0, column=0, columnspan=4)
         self.rectangle = self.canvas.create_rectangle(0, 0, 600, 50, fill='#0097A7')
@@ -107,20 +104,20 @@ class MouserPage(Frame):
 
 
 
-# if __name__ == '__main__':
-#     root = Tk()
-#     root.title("Template Test")
-#     root.geometry('600x600')
+if __name__ == '__main__':
+    root = Tk()
+    root.title("Template Test")
+    root.geometry('600x600')
 
-#     main_frame = MouserPage(root, "Main")
-#     frame = MouserPage(root, "Template")
+    main_frame = MouserPage(root, "Main")
+    frame = MouserPage(root, "Template")
 
-#     main_frame.set_next_button(frame)
-#     frame.set_previous_button(main_frame)
+    main_frame.set_next_button(frame)
+    frame.set_previous_button(main_frame)
 
-#     main_frame.raise_frame()
+    main_frame.raise_frame()
 
-#     root.grid_rowconfigure(0, weight=1)
-#     root.grid_columnconfigure(0, weight=1)
+    root.grid_rowconfigure(0, weight=1)
+    root.grid_columnconfigure(0, weight=1)
 
-#     root.mainloop()
+    root.mainloop()

--- a/tk_models.py
+++ b/tk_models.py
@@ -1,6 +1,6 @@
 from tkinter import *
 from tkinter.ttk import *
-
+from scrollable_frame import ScrolledFrame
 
 def raise_frame(frame: Frame):
     frame.tkraise()
@@ -45,6 +45,9 @@ class MouserPage(Frame):
         super().__init__(parent)
         self.title = title
 
+        style = Style()
+        style.configure("TFrame", background="green")
+
         self.canvas = Canvas(self, width=600, height=600)
         self.canvas.grid(row=0, column=0, columnspan=4)
         self.rectangle = self.canvas.create_rectangle(0, 0, 600, 50, fill='#0097A7')
@@ -54,6 +57,10 @@ class MouserPage(Frame):
         self.grid(row=0, column=0, sticky="NESW")
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
+
+        self.canvas.grid_rowconfigure(0, weight=1)
+        self.canvas.grid_columnconfigure(0, weight=1)
+
         self.menu_button = MenuButton(self, menu_page) if menu_page else None
         self.next_button = None
         self.previous_button = None
@@ -100,20 +107,20 @@ class MouserPage(Frame):
 
 
 
-if __name__ == '__main__':
-    root = Tk()
-    root.title("Template Test")
-    root.geometry('600x600')
+# if __name__ == '__main__':
+#     root = Tk()
+#     root.title("Template Test")
+#     root.geometry('600x600')
 
-    main_frame = MouserPage(root, "Main")
-    frame = MouserPage(root, "Template")
+#     main_frame = MouserPage(root, "Main")
+#     frame = MouserPage(root, "Template")
 
-    main_frame.set_next_button(frame)
-    frame.set_previous_button(main_frame)
+#     main_frame.set_next_button(frame)
+#     frame.set_previous_button(main_frame)
 
-    main_frame.raise_frame()
+#     main_frame.raise_frame()
 
-    root.grid_rowconfigure(0, weight=1)
-    root.grid_columnconfigure(0, weight=1)
+#     root.grid_rowconfigure(0, weight=1)
+#     root.grid_columnconfigure(0, weight=1)
 
-    root.mainloop()
+#     root.mainloop()


### PR DESCRIPTION
**What Was Changed**
Horizontal scroll capability was added to the scroll frame class. 
The class name VerticalScrolledFrame was changed to ScrolledFrame to reflect these changes.
The page and scrollbars now extend to encompass a larger/smaller area when the main window is resized.

The pages using the scroll object were modified to use the new name.
Some extraneous code was removed from VerticalScrolledFrame and its size was changed to reflect window resize.

**Why Was This Changed**
The static sizing of the app window did not allow the optimum user experience when viewing some pages of the app that had the potential to expand greater than the size of the window. 
The cage configuration page was dependent on this capability to be able to comfortably display more/all cages at once.