### PR TITLE
New group name entry bug fix & add "Input Method" label

### DIFF
--- a/experiment_pages/experiment.py
+++ b/experiment_pages/experiment.py
@@ -20,6 +20,9 @@ class Experiment():
         self.data_collect_type = []
         self.date_created = str(date.today())
 
+        self.group_num_changed = False
+        self.measurement_items_changed = False
+
 
     def set_name(self, name):
         self.name = name
@@ -34,7 +37,9 @@ class Experiment():
 
 
     def set_measurement_items(self, items):
-        self.items = items
+        if self.items != items:
+            self.measurement_items_changed = True
+            self.items = items.copy()
 
 
     def set_uses_rfid(self, rfid):
@@ -46,7 +51,9 @@ class Experiment():
 
 
     def set_num_groups(self, num):
-        self.num_groups = num
+        if self.num_groups != num:
+            self.num_groups = num
+            self.group_num_changed = True
 
 
     def set_max_animals(self, num):
@@ -63,6 +70,14 @@ class Experiment():
 
     def set_animals_per_group(self, num):
         self.animals_per_group = num
+
+
+    def set_group_num_changed_false(self):
+        self.group_num_changed = False
+
+
+    def set_measurement_items_changed_false(self):
+        self.measurement_items_changed = False
 
 
     def get_name(self):
@@ -106,10 +121,11 @@ class Experiment():
 
 
     def check_num_groups_change(self):
-        if self.get_num_groups == '0':
-            return False
-        else:
-            return True
+        return self.group_num_changed
+    
+
+    def check_measurement_items_changed(self):
+        return self.measurement_items_changed
 
 
     def add_to_list(self):

--- a/experiment_pages/experiment.py
+++ b/experiment_pages/experiment.py
@@ -20,6 +20,51 @@ class Experiment():
         self.data_collect_type = []
         self.date_created = str(date.today())
 
+
+    def set_name(self, name):
+        self.name = name
+
+
+    def set_investigators(self, invest):
+        self.investigators = invest
+
+
+    def set_species(self, species):
+        self.species = species
+
+
+    def set_measurement_items(self, items):
+        self.items = items
+
+
+    def set_uses_rfid(self, rfid):
+        self.rfid = rfid
+
+
+    def set_num_animals(self, num):
+        self.num_animals = num
+
+
+    def set_num_groups(self, num):
+        self.num_groups = num
+
+
+    def set_max_animals(self, num):
+        self.max_per_cage = num
+
+    
+    def set_group_names(self, names):
+        self.group_names = names
+
+
+    def set_collection_types(self, type):
+        self.data_collect_type = type
+
+
+    def set_animals_per_group(self, num):
+        self.animals_per_group = num
+
+
     def get_name(self):
         return self.name
 
@@ -58,6 +103,13 @@ class Experiment():
 
     def get_collection_types(self):
         return self.data_collect_type
+
+
+    def check_num_groups_change(self):
+        if self.get_num_groups == '0':
+            return False
+        else:
+            return True
 
 
     def add_to_list(self):

--- a/experiment_pages/group_config_ui.py
+++ b/experiment_pages/group_config_ui.py
@@ -71,12 +71,17 @@ class GroupConfigUI(MouserPage):
 
 
     def update_page(self):
-        for widget in self.group_frame.winfo_children():
-            widget.destroy()
-        for widget in self.item_frame.winfo_children():
-            widget.destroy()
-        self.create_group_entries(int(self.input.get_num_groups()))
-        self.create_item_frame(self.input.get_measurement_items())
+        if self.input.check_num_groups_change() == True:
+            for widget in self.group_frame.winfo_children():
+                widget.destroy()
+            self.create_group_entries(int(self.input.get_num_groups()))
+            self.input.set_group_num_changed_false()
+
+        if self.input.check_measurement_items_changed() == True:
+            for widget in self.item_frame.winfo_children():
+                widget.destroy()
+            self.create_item_frame(self.input.get_measurement_items())
+            self.input.set_measurement_items_changed_false()
 
 
     def save_input(self):
@@ -86,11 +91,11 @@ class GroupConfigUI(MouserPage):
             self.input.group_names = group_names
             
         items = self.input.get_measurement_items()
-        measurment_collect_type = []
+        measurement_collect_type = []
         for i in range(0, len(items)):
-            measurment_collect_type.append((items[i], self.button_vars[i].get()))
+            measurement_collect_type.append((items[i], self.button_vars[i].get()))
 
-        self.input.data_collect_type = measurment_collect_type
+        self.input.data_collect_type = measurement_collect_type
         self.next_page.update_page()
 
         

--- a/experiment_pages/group_config_ui.py
+++ b/experiment_pages/group_config_ui.py
@@ -23,8 +23,8 @@ class GroupConfigUI(MouserPage):
         self.group_frame = Frame(self.main_frame)
         self.item_frame = Frame(self.main_frame)
 
-        self.group_frame.grid(row=0, column=0, sticky='NESW')
-        self.item_frame.grid(row=1, column=0, sticky='NESW')
+        self.group_frame.pack(side=TOP)
+        self.item_frame.pack(side=TOP)
 
         self.create_group_entries(int(self.input.get_num_groups()))
         self.create_item_frame(self.input.get_measurement_items())
@@ -55,16 +55,20 @@ class GroupConfigUI(MouserPage):
         self.button_vars = [] 
         self.item_auto_buttons = []
         self.item_man_buttons = []
+
+        type_label = Label(self.item_frame, text="Input Method")
+        type_label.grid(row=0, column=0, columnspan=3, pady=8)
+
         for i in range(0, len(items)):
             self.type = BooleanVar()
             self.button_vars.append(self.type)
             
-            Label(self.item_frame, text=items[i]).grid(row=i, column=0, padx=10, pady=10, sticky=W)
+            Label(self.item_frame, text=items[i]).grid(row=i+1, column=0, padx=10, pady=10, sticky=W)
             auto = Radiobutton(self.item_frame, text='Automatic', variable=self.type, val=True)
             man = Radiobutton(self.item_frame, text='Manual', variable=self.type, val=False)
             
-            auto.grid(row=i, column=1, padx=10, pady=10)
-            man.grid(row=i, column=2, padx=10, pady=10)
+            auto.grid(row=i+1, column=1, padx=10, pady=10)
+            man.grid(row=i+1, column=2, padx=10, pady=10)
 
             self.item_auto_buttons.append(auto)
             self.item_man_buttons.append(man)

--- a/experiment_pages/new_experiment_ui.py
+++ b/experiment_pages/new_experiment_ui.py
@@ -129,12 +129,14 @@ class NewExperimentUI(MouserPage):
             buttons[index].configure(command=f)
             index += 1
 
+
     def get_user_list(self):
         users = self.users_database.get_all_users()
         user_list = []
         for user in users:
             user_list.append(user[1] + " (" + user[3] + ")")
         return user_list
+
 
     def add_investigator(self):
         if self.investigators.get() not in self.added_invest:

--- a/experiment_pages/new_experiment_ui.py
+++ b/experiment_pages/new_experiment_ui.py
@@ -195,15 +195,15 @@ class NewExperimentUI(MouserPage):
 
 
     def save_input(self):
-        self.input.name = self.exper_name.get()
-        self.input.investigators = self.added_invest
-        self.input.species = self.species.get()
-        self.input.items = self.items
-        self.input.rfid = self.rfid.get()
-        self.input.num_animals = self.animal_num.get()
-        self.input.num_groups = self.group_num.get()
-        self.input.max_per_cage = self.num_per_cage.get()
-        self.input.animals_per_group = int(self.animal_num.get()) / int(self.group_num.get())
+        self.input.set_name(self.exper_name.get())
+        self.input.set_investigators(self.added_invest)
+        self.input.set_species(self.species.get())
+        self.input.set_measurement_items(self.items)
+        self.input.set_uses_rfid(self.rfid.get())
+        self.input.set_num_animals(self.animal_num.get())
+        self.input.set_num_groups(self.group_num.get())
+        self.input.set_max_animals(self.num_per_cage.get())
+        self.input.set_animals_per_group(int(self.animal_num.get()) / int(self.group_num.get()))
 
         self.next_page.update_page()
 


### PR DESCRIPTION
**What was changed?**
- experiment class & new_experiment_ui was modified to keep track of changes in user input to the number of groups and measurement items.
- group_config_ui was modified to only destroy group name text boxes and radio buttons if there was a change in user input to the above upon entering and exiting of pages.
- A clarifying label was added above the measurement item radio buttons on group_config_ui 

**Why was this changed?**
- changes were based on client feedback 
- A bug was detected on the group name configuration page in the create new experiment sequence. Previously if the user exited the page the text boxes were destroyed and recreated upon reentry to account for dynamic changes in the number of text boxes populated, however this resulted in the user's input also being deleted and needing to be re-entered upon return to the page.
- The same thing occurred with the state of the radio buttons for measurement items on the same page.
- There was some confusion on what the radio buttons were for so a label was placed above them for user clarification.

**Screenshots**
This showcases both the label and the state of the page after exit and re-entry (the state is the same)
![Screenshot 2023-03-09 233947](https://user-images.githubusercontent.com/102837772/224232872-a71f17b7-aed2-4d62-a3a8-1f9dbb2f60b1.png)


closes #86 
closes #87 