### PR TITLE
Cage Configuration Save to Database

### DIFF
--- a/database_controller.py
+++ b/database_controller.py
@@ -23,7 +23,7 @@ class DatabaseController():
         self.animal_weights = {}
         self.valid_ids = []
         for i in range(1, 21):
-            self.animal_weights[i] = '0'
+            self.animal_weights[i] = str(i)
             self.valid_ids.append(str(i))
         ############################        
 
@@ -49,6 +49,12 @@ class DatabaseController():
     def get_num_cages(self):
         num = len(self.db.get_cages())
         return(num)
+
+
+    def get_cage_max(self):
+        raw_max = self.db.get_cage_max()
+        max = int(raw_max[0][0])
+        return(max)
 
 
     def get_measurement_items(self):
@@ -92,35 +98,37 @@ class DatabaseController():
             return(True)
         else:
             return(False)
+        
+    
+    def check_num_in_cage_allowed(self):
+        max = 0
+        for animals in self.animals_in_cage.values():
+            if len(animals) > max:
+                max = len(animals)
 
+        if max <= self.get_cage_max():
+            return True
+        else:
+            return False
 
+        
     def update_animal_cage(self, animal, old_cage, new_cage):
-        # print('before: ', self.animals_in_cage[old_cage])
         self.animals_in_cage[old_cage].remove(animal)
-        # print('after removal: ', self.animals_in_cage[old_cage])
         self.animals_in_cage[new_cage].append(animal)
-        # print('after add to new: ', self.animals_in_cage[new_cage])
 
 
     def update_experiment(self):
-        # stored & updated values in self.animals_in_cage
-        # save to database
-        self.close_db
+        updated_animals_list = []
+        group_id = 0
+        new_animal_id = 1 # renumber animal ids so they are always in numerical order  
 
+        for group in self.cages_in_group:
+            for cage in self.cages_in_group.get(group):
+                for animal in self.animals_in_cage.get(cage):
+                    animal_tuple = (int(animal), new_animal_id, group_id, int(cage))
+                    updated_animals_list.append(animal_tuple)
+                    new_animal_id += 1
+            group_id += 1
 
-    def close_db(self):
-        self.db.close()
+        self.db.update_animals(updated_animals_list)
 
-
-
-
-if __name__ == '__main__':
-    controller = DatabaseController('Cancer Drug')
-
-    # print(controller.get_cages_in_group('Group B'))
-    print(controller.get_animals_in_cage('5'))
-    print(controller.update_animal_cage('2', '1', '2'))
-
-
-
- 

--- a/database_controller.py
+++ b/database_controller.py
@@ -23,7 +23,7 @@ class DatabaseController():
         self.animal_weights = {}
         self.valid_ids = []
         for i in range(1, 21):
-            self.animal_weights[i] = str(i)
+            self.animal_weights[i] = '0'
             self.valid_ids.append(str(i))
         ############################        
 

--- a/database_controller.py
+++ b/database_controller.py
@@ -37,9 +37,15 @@ class DatabaseController():
 
 
     def reset_attributes(self):
-        self.cages_in_group = self.set_cages_in_group()
-        self.animals_in_cage = self.set_animals_in_cage()
+        ''' reset's the attribute lists so configuration in ui can be saved, 
+            the page can be exited, and then visited again displaying the new config   
+            without destroying all objects 
 
+            can go live when animal map to cage in database is live and working
+        '''
+        # self.cages_in_group = self.set_cages_in_group()
+        # self.animals_in_cage = self.set_animals_in_cage()
+        pass
 
     def get_groups(self):
         raw_groups = self.db.get_all_groups()
@@ -134,7 +140,9 @@ class DatabaseController():
                     updated_animals_list.append(animal_tuple)
                     new_animal_id += 1
             group_id += 1
-
+        
         self.db.update_animals(updated_animals_list)
-        self.reset_attributes()
+
+        ''' can go live when animal map to cage in database is live and working '''
+        # self.reset_attributes()
 

--- a/database_controller.py
+++ b/database_controller.py
@@ -36,6 +36,11 @@ class DatabaseController():
         return(self.db.get_animals_by_cage())
 
 
+    def reset_attributes(self):
+        self.cages_in_group = self.set_cages_in_group()
+        self.animals_in_cage = self.set_animals_in_cage()
+
+
     def get_groups(self):
         raw_groups = self.db.get_all_groups()
         groups = []
@@ -131,4 +136,5 @@ class DatabaseController():
             group_id += 1
 
         self.db.update_animals(updated_animals_list)
+        self.reset_attributes()
 

--- a/experiment_pages/cage_config_ui.py
+++ b/experiment_pages/cage_config_ui.py
@@ -9,6 +9,7 @@ class CageConfigurationUI(MouserPage):
     def __init__(self, database, parent: Tk, prev_page: Frame = None):
         super().__init__(parent, "Group Configuration", prev_page)
 
+        self.prev_page = prev_page
         self.db = DatabaseController(database)
 
         scroll_canvas = ScrolledFrame(self)
@@ -151,15 +152,17 @@ class CageConfigurationUI(MouserPage):
 
         if option == 1:
             label = Label(message, text='Animal ID and Cage ID must be integers.')
-            label.grid(row=0, column=0, padx=10, pady=10)
 
         elif option == 2:
             label = Label(message, text='Not a valid Animal ID.')
-            label.grid(row=0, column=0, padx=10, pady=10)
 
         elif option == 3:
             label = Label(message, text='Not a valid Cage ID.')
-            label.grid(row=0, column=0, padx=10, pady=10)
+
+        elif option == 4:
+            label = Label(message, text='Number of animals in a cage must not exceed '+ str(self.db.get_cage_max()))
+        
+        label.grid(row=0, column=0, padx=10, pady=10)
 
         ok_button = Button(message, text="OK", width=10, 
                         command= lambda: [message.destroy()])
@@ -191,8 +194,14 @@ class CageConfigurationUI(MouserPage):
             self.move_animal(animal, cage)
 
 
+    def check_num_in_cage_allowed(self):
+        return self.db.check_num_in_cage_allowed()
+
+
     def save_to_database(self):
-        # TO-DO : save to database
-        # TO-DO : return to menu
-        pass
+        if self.check_num_in_cage_allowed() == True:
+            self.db.update_experiment()
+            self.prev_page.tkraise()
+        else:
+            self.raise_warning(4)
 

--- a/experiment_pages/cage_config_ui.py
+++ b/experiment_pages/cage_config_ui.py
@@ -60,7 +60,6 @@ class CageConfigurationUI(MouserPage):
 
     def create_group_frames(self):
         groups = self.db.get_groups()
-        self.group_frames = {}  # dict of {group name : frame id}
 
         frame_style, label_style = Style(), Style()
         frame_style.configure('GroupFrame.TFrame', background='#0097A7')
@@ -73,13 +72,11 @@ class CageConfigurationUI(MouserPage):
             
             self.create_cage_frames(group, frame)
             frame.pack(side=TOP, expand=TRUE, fill=BOTH, anchor='center')
-            self.group_frames[group] = frame
            
 
     def create_cage_frames(self, group, group_frame):
         cages = self.db.get_cages_in_group(group)
         meas_items = self.db.get_measurement_items()
-        self.cage_frames = {}  # dict of {cage num : frame id}
 
         for i in range (0, len(cages)):
             frame = Frame(group_frame, borderwidth=3, relief='groove')
@@ -96,12 +93,10 @@ class CageConfigurationUI(MouserPage):
             self.create_animal_frames(cages[i], frame)
             
             frame.pack(side=LEFT, expand=TRUE, fill=BOTH, anchor='center')
-            self.cage_frames[cages[i]] = frame
 
        
     def create_animal_frames(self, cage, cage_frame):
         animals = self.db.get_animals_in_cage(cage)
-        self.animal_frames = {}  # dict of {animal id : frame id}
 
         for animal in animals:
             frame = Frame(cage_frame, borderwidth=3, relief='groove')
@@ -115,8 +110,7 @@ class CageConfigurationUI(MouserPage):
 
             id_measurement_frame.pack(side=TOP, expand=TRUE, fill=BOTH, anchor='center')
 
-            frame.pack(side=TOP, expand=TRUE, fill=BOTH, anchor='center', padx= 5, pady= 5, ipadx= 5, ipady= 5)
-            self.cage_frames[animal] = frame            
+            frame.pack(side=TOP, expand=TRUE, fill=BOTH, anchor='center', padx= 5, pady= 5, ipadx= 5, ipady= 5)      
 
 
     def clear_entry(self, event, input):

--- a/experiment_pages/experiment_menu_ui.py
+++ b/experiment_pages/experiment_menu_ui.py
@@ -29,7 +29,7 @@ class ExperimentMenuUI(MouserPage):
         analysis_button = Button(main_frame, text='Data Analysis', width=button_size,
                                 command= lambda: analysis_page.raise_frame())
         group_button = Button(main_frame, text='Group Configuration', width=button_size,
-                                command= lambda: cage_page.raise_frame())
+                                command= lambda: [cage_page.raise_frame(), cage_page.update_config_frame()])
         rfid_button = Button(main_frame, text='Map RFID', width=button_size,
                                 command= lambda: rfid_page.raise_frame())
         invest_button = Button(main_frame, text='Investigators', width=button_size,


### PR DESCRIPTION
**What Was Changed?**
Current state of animals/cages/groups in Group Configuration UI page saves to the database upon click of 'Save' button. 
- Animal Ids re-order numerically based on what cage they are moved to based on client's request and are saved to the database in that fashion. (i.e. Cage 1 always houses Animal 1 and so forth)


**Known Bugs:**
There is not currently a place within the UI application that puts animals/animal ids into cages and saves to the database, based on the call written for saving to the database there needs to be a value present to update. Because our test experiments in the application do not have this feature, the call does not work properly when using the UI alone. 
- Testing outside the UI found that the calls made work as expected, however the current loaded experiment in the UI needs to be set up properly for it to appear in the UI. One this functionality is added to the app, the changes made in this PR will work as desired.


closes #29 