### PR TITLE
Cage Group Display Horizontal

### DIFF
--- a/experiment_pages/cage_config_ui.py
+++ b/experiment_pages/cage_config_ui.py
@@ -74,7 +74,8 @@ class CageConfigurationUI(MouserPage):
             label.pack(side=TOP, padx=self.pad_x, pady=self.pad_y, anchor='center')
             
             self.create_cage_frames(group, frame)
-            frame.pack(side=TOP, expand=TRUE, fill=BOTH, anchor='center')
+            #Only Necessary Change is the side of the frame. From TOP to LEFT gives us the cage groups horizontally.
+            frame.pack(side=LEFT, expand=TRUE, fill=BOTH, anchor='center')
            
 
     def create_cage_frames(self, group, group_frame):
@@ -96,7 +97,6 @@ class CageConfigurationUI(MouserPage):
             self.create_animal_frames(cages[i], frame)
             
             frame.pack(side=LEFT, expand=TRUE, fill=BOTH, anchor='center')
-
        
     def create_animal_frames(self, cage, cage_frame):
         animals = self.db.get_animals_in_cage(cage)


### PR DESCRIPTION
Change cage group configuration to display vertically, to horizontally.

Fixes #110

**What was changed?**

Change cage group configuration to display vertically, to horizontally. Only had to rewrite one line of code, placing the side of the frame as left instead of top.

**Why was it changed?**
Was an issue listed, also much easier to read without required scrolling for multiple cage groups.
**How was it changed?**
Simply rewrote the frame.pack() line to display side to side instead of top to bottom.
**Screenshots that show the changes (if applicable):**
<img width="1440" alt="Screen Shot 2023-10-12 at 2 17 52 PM" src="https://github.com/oss-slu/Mouser/assets/99059695/96cee0a7-a1b2-4c84-9680-4b48550adf78">
<img width="1440" alt="Screen Shot 2023-10-12 at 2 18 55 PM" src="https://github.com/oss-slu/Mouser/assets/99059695/b04b0cdc-3729-4af4-9280-6b57f51ff58f">
