### PR TITLE
Implement serial port selection for measurement

### DIFF
--- a/experiment_pages/map_rfid.py
+++ b/experiment_pages/map_rfid.py
@@ -5,8 +5,7 @@ import tkinter.font as tkfont
 import random
 from playsound import playsound
 import threading
-import serial.tools.list_ports
-import serial
+from serial_port_controller import SerialPortController
 
 from database_apis.experiment_database import ExperimentDatabase
 
@@ -217,7 +216,7 @@ class SerialPortSelection():
         self.parent = parent
         self.map_rfid = map_rfid
         self.id = None
-        self.ports_in_used = []     #prevent user from selecting ports in use
+        self.portController = SerialPortController()
     
     def open(self):
         root = Toplevel(self.parent)
@@ -250,18 +249,14 @@ class SerialPortSelection():
 
 
     def update_ports(self):
-        self.available_ports = []
-        ports = list(serial.tools.list_ports.comports())
-
-        for port_ in ports:
-            if (port_ in self.ports_in_used):       #prevention
-                pass
-            else:
-                self.available_ports.append((f'{port_.device}', f'{port_.description}'))
+        ports = self.portController.get_available_ports()
+        for port in ports:
+            if (ports[0].isOpen()):
+                self.portController.close_port()
         self.table.tag_configure('TkTextFont', font=tkfont.nametofont('TkTextFont'))
         style = Style()
         style.configure('TkTextFont', font = (NONE,30))
-        for line in self.available_ports:
+        for line in ports:
             self.table.insert('', END, values = line, tags='TkTextFont')
         
     def item_selected(self, event):
@@ -270,17 +265,13 @@ class SerialPortSelection():
 
     def conform_selection(self):
         if (self.id != None):
-            port_info = self.table.item(self.id)       #port_info = ['port name', 'description']
-            self.read_information(port_info)
+            item_details = self.table.item(self.id)      #port_info = ['port name', 'description']
+            print(len(item_details))
+            port_info = item_details.get("values")
+            print(port_info[0])
+            self.portController.read_info(port_info[0])
 
 
-
-    def read_information(self, port: str):
-        # Todo: open the selected serial port, add it into the ports_in_use list
-        # Todo: read data from the port and store it in database
-        # Todo: close the port
-        print(port)
-        pass
 
 
 

--- a/experiment_pages/map_rfid.py
+++ b/experiment_pages/map_rfid.py
@@ -250,9 +250,6 @@ class SerialPortSelection():
 
     def update_ports(self):
         ports = self.portController.get_available_ports()
-        for port in ports:
-            if (ports[0].isOpen()):
-                self.portController.close_port()
         self.table.tag_configure('TkTextFont', font=tkfont.nametofont('TkTextFont'))
         style = Style()
         style.configure('TkTextFont', font = (NONE,30))
@@ -266,10 +263,9 @@ class SerialPortSelection():
     def conform_selection(self):
         if (self.id != None):
             item_details = self.table.item(self.id)      #port_info = ['port name', 'description']
-            print(len(item_details))
             port_info = item_details.get("values")
-            print(port_info[0])
-            self.portController.read_info(port_info[0])
+            #self.portController.read_info(port_info[0])
+            # Todo: complete the implementation of read_info in serial_port_controller
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ playsound
 tkcalendar
 pandas
 getmac
+pyserial

--- a/serial_port_controller.py
+++ b/serial_port_controller.py
@@ -1,0 +1,58 @@
+import serial.tools.list_ports
+import serial
+
+
+
+# recommendation: use com0com to create virtual serial ports and PuTTy to display the result
+# to do so, connect the two serial ports from com0com, one for reading on PuTTy (not with our code) 
+# and one for writing (with our code)
+
+class SerialPortController():
+    def __init__(self):
+        self.ports_in_used = []
+
+
+    def get_available_ports(self):
+        available_ports = []
+        ports = list(serial.tools.list_ports.comports())
+
+        for port_ in ports:
+            if (port_ in self.ports_in_used):       #prevention
+                pass
+            else:
+                available_ports.append((f'{port_.device}', f'{port_.description}'))
+        return available_ports
+    
+    def close_port(self, ser: serial, port: str):
+        if (ser.isOpen()):
+            ser.close()
+        if ser.name in self.ports_in_used:
+            self.ports_in_used.remove(port)
+    
+    def read_info(self, port: str):
+        ser = serial.Serial(port, 9600, timeout = 1)
+        self.ports_in_used.append(port)
+        if (ser.isOpen()):
+            ser.close()
+        ser.open()
+        while True:         # continue asking for data until the other device closes
+            info = ser.readline().decode('ascii')
+            print(info)
+        self.close_port(ser, port)
+        # Todo: read data from the port and store it in database
+        # Todo: break out of the loop if the time taken to get data is too long
+
+
+
+    #for testing purpose only, this function currently doesn't work well
+    def write_info(self, port: str):
+        ser = serial.Serial(port, 9600, timeout = 1, write_timeout=1)
+        message = ""
+        while (message != "q"):
+            message = input('type something: ')
+            print(message)
+            byte_message = message.encode()
+            print('1')
+            ser.write(byte_message)
+
+        ser.close()

--- a/serial_port_controller.py
+++ b/serial_port_controller.py
@@ -37,7 +37,6 @@ class SerialPortController():
         ser.open()
         while True:         # continue asking for data until the other device closes
             info = ser.readline().decode('ascii')
-            print(info)
         self.close_port(ser, port)
         # Todo: read data from the port and store it in database
         # Todo: break out of the loop if the time taken to get data is too long
@@ -50,9 +49,7 @@ class SerialPortController():
         message = ""
         while (message != "q"):
             message = input('type something: ')
-            print(message)
             byte_message = message.encode()
-            print('1')
             ser.write(byte_message)
 
         ser.close()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,18 @@
+import serial.tools.list_ports
+import serial
+
+
+#this file has nothing to do with main Mouser, just as a test file for different things
+data = []
+ports = list(serial.tools.list_ports.comports())
+print(len(ports))
+for port_ in ports:
+    print("device: ", port_.device, "description: ", port_.description)
+
+ser = serial.Serial(ports[1].device, 9600, timeout = 1)
+message = "Hello whoever you are\n"
+ser.write(message.encode('ascii'))
+word = ser.readline().decode('ascii')
+print(word)
+
+print('hello')


### PR DESCRIPTION
Fixes #114 


Map RFID file has been changed so that there's an option to access to a new GUI serial Port that allow user to select which serial port they want to use for the experiment. 

The changes were made because there's no function to select a serial port to transfer data previously. 

The changes were made by creating a new button on the Map RFID GUI that access a serial port GUI containing table of the name of available ports provided by the pc as well as the description of those ports. Users can select the GUI they want to use by selecting the name of the serial port directly and then hit Select Port button at the bottom. However, the button doesn't do anything currently as there's limited ways to test the functionality of serial port.

[serialPortGUI_before_after.pdf](https://github.com/oss-slu/Mouser/files/13062386/serialPortGUI_before_after.pdf)

