### PR TITLE
126 experiment deletion error

### DIFF
--- a/experiment_pages/experiment_menu_ui.py
+++ b/experiment_pages/experiment_menu_ui.py
@@ -101,7 +101,6 @@ class ExperimentMenuUI(MouserPage):
             for line in reader:
                 if line[0] != name:
                     experiment_list.append(line)
-            print(experiment_list)
 
         with open('./database_apis/created_experiments.csv', 'w', newline="") as f:
             writer = csv.writer(f)

--- a/experiment_pages/experiment_menu_ui.py
+++ b/experiment_pages/experiment_menu_ui.py
@@ -92,6 +92,7 @@ class ExperimentMenuUI(MouserPage):
             os.remove(file)
         except OSError as error:
             print(error)
+            return
 
         #delete from experiment selection file from the created_experiments csv
         experiment_list = []
@@ -100,7 +101,9 @@ class ExperimentMenuUI(MouserPage):
             for line in reader:
                 if line[0] != name:
                     experiment_list.append(line)
-        with open('./database_apis/created_experiments.csv', 'w') as f:
+            print(experiment_list)
+
+        with open('./database_apis/created_experiments.csv', 'w', newline="") as f:
             writer = csv.writer(f)
             writer.writerows(experiment_list)
 


### PR DESCRIPTION
Fixes #126 

**What was changed?**

experiment_pages_ui.py
- delete_experiment()

**Why was it changed?**

While delete experiments, would overwrite created_experiments.csv would create extra empty lines in the file. This caused errors when other methods tried to read the file. Changed it so they no longer appear. 

**How was it changed?**
```
open('./database_apis/created_experiments.csv', 'w')
```
is now
```
open('./database_apis/created_experiments.csv', 'w', newline="")
```
Overrides the default newline character with an empty string so that it doesn't create empty lines.

Added a return line so that when there is an OS error in the delete_experiment method it doesn't continue delete the entry in created_experiments.csv
