### PR TITLE
Fix Remove RFID

### DIFF
--- a/experiment_pages/map_rfid.py
+++ b/experiment_pages/map_rfid.py
@@ -161,9 +161,17 @@ class MapRFIDPage(MouserPage):
         else:
             self.delete_button["state"] = "normal"
 
+    
     def remove_selected_items(self):
         for item in self.table.selection():
+            # Animal ID Before Removing
+            animal_id_remove = int(self.table.item(item, 'values')[0])
+            
             self.table.delete(item)
+
+            # If Animal ID is greater than the ID to remove, subtract the animal ID by one
+            if self.animal_id > animal_id_to_remove:
+                self.animal_id -= 1
 
     def open_change_rfid(self):
         self.changing_value = self.table.selection()[0]


### PR DESCRIPTION
Remove RFID just removes it from the GUI. The database still has it existing. When a new selection is placed after a RFID is removed, it proceeds to give the animal id to the number following the deleted rfid. So if an experiment has 10 animals, one is deleted, you are actually only able to have 9 animals in the experiment.

Fixes #issue_number

Issue #124 

*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*
Not finished, but trying to have the animal id be updated after the selection is removed.

*Here, describe the issue that you are fixing with this code, and why your code fixes it.*

It should be simple as I just need the current animal id to be subtracted by one following removal, but not working yet.

*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*
Working with both the map_rfid and experiments_database files together.
