### PR TITLE
implementation of method that allow serial port to sent rfid

### DIFF
--- a/serial_port_controller.py
+++ b/serial_port_controller.py
@@ -78,3 +78,18 @@ class SerialPortController():
         self.close_reader_port()
         self.close_writer_port()
 
+    
+    def get_reader_port(self):
+        return self.reader_port
+    
+    def get_writer_port(self):
+        return self.writer_port
+    
+
+
+    # testing function for map_rfid serial port
+    def get_set_RFID(self, rfid: int):
+        message = rfid.encode()
+        self.writer_port.write(message)
+    
+


### PR DESCRIPTION
Fixes #113

Improvement are made to the original serial port selection panel that allow it to choose the serial port to get the rfid from.

Originally, the panel was set up so to allow the Mouser application to have the ability to connect to other device via serial port. However, the actual implementation of connection hasn't been set up yet, so it currently resides in the map_rfid page. The changes made from this branch now allows this functionality to select a serial port from the available serial ports to read and obtain the rfid for the animals.

The changes were implemented by creating a serial port controller in the map_rfid page and connect the functionality of the controller to read from the serial port to the original function that add the rfid to the animal label. The selection of serial port occurs in the select serial port panel from the select serial port button that sets the selected serial port as reader port. However, since there's no other serial port available other than the virtual port, a functionality was created so that when the user selects one of the serial port, the program will select the other virtual port as the writer port. 

To test that the implementation is functional, a predetermined was written to the writer port once the serial port were set such that whenever user simulates rfid for the animals, the first three digit of the rfid will be "123" and the rest will be random numbers. This is the case because rfid has to be unique.

