### PR TITLE
Update Opening Frame

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,10 +29,8 @@ create_nav_button(main_frame, "Accounts", user_image,
                   accounts_frame, 0.5, 0.67)
 
 
-raise_frame(login_frame)
+raise_frame(main_frame)
 
-login_frame.remove_outdated_auto_login()
-login_frame.auto_login()
 
 root.grid_rowconfigure(0, weight=1)
 root.grid_columnconfigure(0, weight=1)

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ create_nav_button(main_frame, "Accounts", user_image,
                   accounts_frame, 0.5, 0.67)
 
 
-raise_frame(main_frame)
+raise_frame(experiments_frame)
 
 
 root.grid_rowconfigure(0, weight=1)


### PR DESCRIPTION
Removes the login page from the main frame, automatically displays the accounts/ experiments option. In future, will automatically go to experiments page when accounts are removed.

Fixes #139 

The login frames that were instructed to be raised when the main would run was removed and replaced with the main_frame which asks users for either accounts or experiments.

The login screen/ opening frame.

Was unnecessary for our clients use.

Just redirects the main to run without the login page.

Slight change of code and removal of login frames on main.

<img width="590" alt="Screen Shot 2023-11-22 at 12 57 17 PM" src="https://github.com/oss-slu/Mouser/assets/99059695/43492c9d-dd7a-4d1f-b7f5-6dce41c25b20">
