### PR TITLE
Added menu bar that has an option to open a file from any location

### DIFF
--- a/database_apis/data_collection_database.py
+++ b/database_apis/data_collection_database.py
@@ -4,10 +4,16 @@ import os
 
 class DataCollectionDatabase:
     def __init__(self, experiment: str = None, measurement_items: list = ["Weight", "Length"]):
-        if not experiment:
+        
+        #gets the name of the file from the file path
+        experiment_name = os.path.basename(experiment)
+        experiment_name = os.path.splitext(experiment_name)[0]
+
+
+        if not experiment_name:
             self.filename = "data.csv"
         else:
-            self.filename = experiment + ".csv"
+            self.filename = experiment_name + ".csv"
         
         self.filename = "database_apis/fake_data/" + self.filename
         try:

--- a/database_controller.py
+++ b/database_controller.py
@@ -5,7 +5,7 @@ import copy
 class DatabaseController():
     def __init__(self, database):
         
-        file = 'databases/experiments/' + str(database) + '.db'
+        file = database
         self.db = ExperimentDatabase(file)
 
         # self.measurement_items = self.db.get_measurement_items()

--- a/experiment_pages/data_collection_ui.py
+++ b/experiment_pages/data_collection_ui.py
@@ -11,7 +11,7 @@ class DataCollectionUI(MouserPage):
     def __init__(self, parent: Tk, prev_page: Frame = None, database_name = ""):
         super().__init__(parent, "Data Collection", prev_page)
         
-        self.database = ExperimentDatabase("databases/experiments/" + database_name + ".db")
+        self.database = ExperimentDatabase(database_name)
         self.measurement_items = self.database.get_measurement_items()
         self.measurement_strings = []
         self.measurement_ids = []

--- a/experiment_pages/experiment_menu_ui.py
+++ b/experiment_pages/experiment_menu_ui.py
@@ -13,7 +13,11 @@ from experiment_pages.experiment_invest_ui import InvestigatorsUI
 
 class ExperimentMenuUI(MouserPage):
     def __init__(self, parent:Tk, name: str, prev_page: ChangeableFrame = None):
-        super().__init__(parent, name, prev_page)
+        #Get name of file from file path
+        experiment_name = os.path.basename(name)
+        experiment_name = os.path.splitext(experiment_name)[0]
+
+        super().__init__(parent, experiment_name, prev_page)
         
         main_frame = Frame(self)
         main_frame.grid(row=6, column=1, sticky='NESW')

--- a/experiment_pages/map_rfid.py
+++ b/experiment_pages/map_rfid.py
@@ -27,7 +27,7 @@ class MapRFIDPage(MouserPage):
     def __init__(self, database, parent: Tk, previous_page: Frame = None):
         super().__init__(parent, "Map RFID", previous_page)
 
-        file = "databases/experiments/" + str(database) + '.db'
+        file = database
         self.db = ExperimentDatabase(file)
         self.serial_port_controller = SerialPortController()
 

--- a/experiment_pages/select_experiment_ui.py
+++ b/experiment_pages/select_experiment_ui.py
@@ -1,4 +1,5 @@
 from tkinter import *
+from tkinter.filedialog import *
 from tkinter.ttk import *
 from tk_models import *
 from scrollable_frame import ScrolledFrame
@@ -25,6 +26,13 @@ class ExperimentsUI(MouserPage, ChangeableFrame):
     def __init__(self, parent:Tk, prev_page: Frame = None):
         super().__init__(parent, "Experiments", prev_page)
         self.parent = parent
+
+        #Adds menu bar to root and binds the function to file_menu
+        menu_bar = Menu(parent)
+        file_menu = Menu(menu_bar, tearoff= 0)
+        file_menu.add_command(label = "Open", command = self.open_file)
+        menu_bar.add_cascade(label = "File", menu=file_menu)
+        parent.config(menu=menu_bar)
 
         NewExperimentButton(parent, self)
 
@@ -97,3 +105,8 @@ class ExperimentsUI(MouserPage, ChangeableFrame):
         page = ExperimentMenuUI(self.parent, name, self)
         page.tkraise()
 
+    #command for 'open' option in menu bar
+    def open_file(self):
+        file_path = askopenfilename(filetypes=[("Databse files","*.db")]);
+        page = ExperimentMenuUI(self.parent, file_path, self)
+        page.tkraise()

--- a/experiment_pages/select_experiment_ui.py
+++ b/experiment_pages/select_experiment_ui.py
@@ -27,13 +27,6 @@ class ExperimentsUI(MouserPage, ChangeableFrame):
         super().__init__(parent, "Experiments", prev_page)
         self.parent = parent
 
-        #Adds menu bar to root and binds the function to file_menu
-        menu_bar = Menu(parent)
-        file_menu = Menu(menu_bar, tearoff= 0)
-        file_menu.add_command(label = "Open", command = self.open_file)
-        menu_bar.add_cascade(label = "File", menu=file_menu)
-        parent.config(menu=menu_bar)
-
         NewExperimentButton(parent, self)
 
         self.main_frame = Frame(self)
@@ -105,8 +98,3 @@ class ExperimentsUI(MouserPage, ChangeableFrame):
         page = ExperimentMenuUI(self.parent, name, self)
         page.tkraise()
 
-    #command for 'open' option in menu bar
-    def open_file(self):
-        file_path = askopenfilename(filetypes=[("Databse files","*.db")]);
-        page = ExperimentMenuUI(self.parent, file_path, self)
-        page.tkraise()

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from experiment_pages.select_experiment_ui import ExperimentsUI
 #command for 'open' option in menu bar
 def open_file():
     file_path = askopenfilename(filetypes=[("Database files","*.db")]);
-    page = ExperimentMenuUI(root, file_path, main_frame)
+    page = ExperimentMenuUI(root, file_path, experiments_frame)
     page.tkraise()
 
 

--- a/main.py
+++ b/main.py
@@ -8,10 +8,13 @@ from accounts import AccountsFrame
 from experiment_pages.select_experiment_ui import ExperimentsUI
 
 
+
 root = Tk()
 root.title("Mouser")
 root.geometry('600x600')
 root.minsize(600,600)
+
+
 
 
 main_frame = MouserPage(root, "Mouser")

--- a/main.py
+++ b/main.py
@@ -1,12 +1,19 @@
 from tkinter import *
 from tkinter.ttk import *
+from tkinter.filedialog import *
 from turtle import onclick
 from login import LoginFrame
 from tk_models import *
+from experiment_pages.experiment_menu_ui import ExperimentMenuUI
 
 from accounts import AccountsFrame
 from experiment_pages.select_experiment_ui import ExperimentsUI
 
+#command for 'open' option in menu bar
+def open_file():
+    file_path = askopenfilename(filetypes=[("Database files","*.db")]);
+    page = ExperimentMenuUI(root, file_path, main_frame)
+    page.tkraise()
 
 
 root = Tk()
@@ -14,8 +21,12 @@ root.title("Mouser")
 root.geometry('600x600')
 root.minsize(600,600)
 
-
-
+#Adds menu bar to root and binds the function to file_menu
+menu_bar = Menu(root)
+file_menu = Menu(menu_bar, tearoff= 0)
+file_menu.add_command(label = "Open", command = open_file)
+menu_bar.add_cascade(label = "File", menu=file_menu)
+root.config(menu=menu_bar)
 
 main_frame = MouserPage(root, "Mouser")
 login_frame = LoginFrame(root, main_frame)
@@ -41,3 +52,5 @@ root.grid_rowconfigure(0, weight=1)
 root.grid_columnconfigure(0, weight=1)
 
 root.mainloop()
+
+


### PR DESCRIPTION
Fixes #140 

**What was changed?**

Added a menu bar that contains the functionality to open a database file from anywhere on their computer.

**Why was it changed?**

The previous code would not be able to handle the user moving the .db file to anywhere other than the previously hard-coded directory.

**How was it changed?**

Menu objects are used to create a drop down menu at the top of the window. This is done in the initialization of the ExperimentUI object. (Lines 31-35 of select_experiment_ui.py)

The funcition *open_file()* asks the user to select a file using their native OS's file chooser. It then instantiates an ExperimentMenuUI object using the given file as the name. (Lines 109-112)

Changed initializers in data_collection_ui.py, database_controller.py, data_colection_database.py, and map_rfid.py to work when given a full file path as opposed to just the name of the experiment.
