### PR TITLE
implementing unique id generation for experiment

### DIFF
--- a/database_apis/experiment_database.py
+++ b/database_apis/experiment_database.py
@@ -11,7 +11,8 @@ class ExperimentDatabase:
                                 uses_rfid INTEGER,
                                 num_animals INTEGER,
                                 num_groups INTEGER,
-                                cage_max INTEGER);''')
+                                cage_max INTEGER,
+                                id TEXT);''')
             self._c.execute('''CREATE TABLE animals (
                                 animal_id INTEGER PRIMARY KEY,
                                 group_id INTEGER,
@@ -41,10 +42,10 @@ class ExperimentDatabase:
             pass
 
 
-    def setup_experiment(self, name, species, uses_rfid, num_animals, num_groups, cage_max):
-        self._c.execute(''' INSERT INTO experiment (name, species, uses_rfid, num_animals, num_groups, cage_max) 
-                            VALUES (?, ?, ?, ?, ?, ?)''',
-                            (name, species, uses_rfid, num_animals, num_groups, cage_max))
+    def setup_experiment(self, name, species, uses_rfid, num_animals, num_groups, cage_max, id):
+        self._c.execute(''' INSERT INTO experiment (name, species, uses_rfid, num_animals, num_groups, cage_max, id) 
+                            VALUES (?, ?, ?, ?, ?, ?, ?)''',
+                            (name, species, uses_rfid, num_animals, num_groups, cage_max, id))
         self._conn.commit()
 
     def setup_groups(self, group_names):

--- a/experiment_pages/experiment.py
+++ b/experiment_pages/experiment.py
@@ -1,4 +1,5 @@
 import csv
+import uuid
 from datetime import date
 from database_apis.experiment_database import ExperimentDatabase
 from database_apis.experiment_database import ExperimentDatabase
@@ -11,6 +12,7 @@ class Experiment():
         self.investigators = []
         self.species = ''
         self.items = []
+        self.id = ''
         self.rfid = False
         self.num_animals = ''
         self.num_groups = '0'
@@ -58,6 +60,10 @@ class Experiment():
 
     def set_max_animals(self, num):
         self.max_per_cage = num
+    
+    def set_unique_id(self):
+        unique_id = uuid.uuid1()
+        self.id = str(unique_id)
 
     
     def set_group_names(self, names):
@@ -140,7 +146,7 @@ class Experiment():
         file = 'databases/experiments/' + self.name + '.db'
         db = ExperimentDatabase(file)
         db.setup_experiment(self.name, self.species, self.rfid, self.num_animals, 
-                            self.num_groups, self.max_per_cage)
+                            self.num_groups, self.max_per_cage, self.id)
         db.setup_groups(self.group_names)
         db.setup_cages(self.num_animals, self.num_groups, self.max_per_cage)
         db.setup_measurement_items(self.data_collect_type)

--- a/experiment_pages/new_experiment_ui.py
+++ b/experiment_pages/new_experiment_ui.py
@@ -221,6 +221,7 @@ class NewExperimentUI(MouserPage):
     def save_input(self):
         if self.check_name_exist():
             self.input.set_name(self.exper_name.get())
+            self.input.set_unique_id()
             self.input.set_investigators(self.added_invest)
             self.input.set_species(self.species.get())
             self.input.set_measurement_items(self.items)


### PR DESCRIPTION
Fixes #123

A method to add unique id to the experiment has been created. New column added to the experiment table of the database file.

The feature is implemented because a unique id is needed to label the experiment instead of experiment name (there's a warning that avoid duplicated naming convention).

Package uuid is used that can generate random id is used to create the id for the experiment. Each time an experiment is created, there'll be a random id generated by uuid. To record the id, a new column called id is created in the experiment_database.py that's used to record the id.
