### PR TITLE
Reimplemented the delete function

### DIFF
--- a/experiment_pages/experiment_menu_ui.py
+++ b/experiment_pages/experiment_menu_ui.py
@@ -94,6 +94,12 @@ class ExperimentMenuUI(MouserPage):
 
         # disconnect the file from the database
         self.disconnect_database()
+        print(name)
+        splitted = name.split("\\")
+        print(splitted[-1])
+        if ("Protected" in splitted[-1]):
+            name = "C:\\Users\\stanl\\capstone1\\mouser\\Mouser\\databases\\experiments\\" + splitted[-1]
+            
 
         try:
             os.remove(name)

--- a/experiment_pages/experiment_menu_ui.py
+++ b/experiment_pages/experiment_menu_ui.py
@@ -89,22 +89,16 @@ class ExperimentMenuUI(MouserPage):
 
 
     def delete_experiment(self, page: Frame, name: str):
-        # TO-DO delete database
-        # TO-DO delete from experiment selection file
-        # TO-DO return to experiment selection page
+        
+        # TO-DO remove the protected file when deleted
 
-        #delete from database
+        # disconnect the file from the database
         self.disconnect_database()
-        file = "databases/experiments/" + name + '.db'
+
         try:
-            os.remove(file)
+            os.remove(name)
         except OSError as error:
-            print(error)
+            print("error from deleting experiment: ",error)
             return
 
-        # #return to experiment selection page 
-        # problem: the selection page still has the experiment
-        page.update_frame()
         page.tkraise()
-
-


### PR DESCRIPTION
Fixes #166 

**What was changed?**

The delete experiment function was changed such that it now properly deletes the experiment files when the warning window pops up and the user pressed yes.

However, another problem arose with recent version of Mouser is that it won't delete the protected experiment files due to the way protected file is displayed. The protected file seen in Mouser is a new file created in temporary directory of the device, and the path it stores does not point to the actual location of the file but the temporary directory instead.

**Why was it changed?**

The delete function is changed because the logic of how we opened the experiment file from the mouse application is changed. Originally the delete function uses the name of the experiment to delete the experiment. However, now the experiment name would return the entire file path of the experiment file in user's computer, which impacted how the original delete function works.

**How was it changed?**

Since the experiment name gives the entire file path of the experiment file, all it takes is to remove the original implementation of deleting the previous directory+name+.db to the name itself.

**Screenshots that show the changes (if applicable):**
