### PR TITLE
Fixing incorrect password error

### DIFF
--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -77,9 +77,9 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         yes_button.grid(row=2, column=0, padx=10, pady=10)
         no_button.grid(row=2, column=1, padx=10, pady=10)
 
-        for i in range(0,3):
-            message.grid_rowconfigure(i, 1)
-            message.grid_columnconfigure(i, 1)
+        #for i in range(0,3):
+        #    message.grid_rowconfigure(i, 1)
+        #    message.grid_columnconfigure(i, 1)
 
         message.mainloop()
 
@@ -96,7 +96,8 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         self.disconnect_database()
         splitted = name.split("\\")
         if ("Protected" in splitted[-1]):
-            name = "C:\\Users\\stanl\\capstone1\\mouser\\Mouser\\databases\\experiments\\" + splitted[-1]
+            path = os.getcwd()
+            name = path + "\\databases\\experiments\\" + splitted[-1]
             
 
         try:

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -55,7 +55,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         group_button.grid(row=2, column=0, ipady=10, ipadx=10, pady=10, padx=10)
         rfid_button.grid(row=3, column=0, ipady=10, ipadx=10, pady=10, padx=10)
         invest_button.grid(row=4, column=0, ipadx=10, ipady=10, pady=10, padx=10)
-        delete_button.grid(row=5, column=0, ipadx=10, ipady=10, pady=10, padx=10)
+        delete_button.grid(row=5, column=0, ipadx=10, ipady=10, pady=10, padx=10)   
 
 
     def delete_warning(self, page: CTkFrame, name: str):
@@ -94,9 +94,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
 
         # disconnect the file from the database
         self.disconnect_database()
-        print(name)
         splitted = name.split("\\")
-        print(splitted[-1])
         if ("Protected" in splitted[-1]):
             name = "C:\\Users\\stanl\\capstone1\\mouser\\Mouser\\databases\\experiments\\" + splitted[-1]
             

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 '''Main functionality of Program.'''
+import shutil
 import tempfile
 from tkinter.filedialog import *
 from customtkinter import *
@@ -40,24 +41,17 @@ def open_file():
                     temp_file_name =  os.path.basename(file_path)
                     temp_file_path = os.path.join(temp_folder_path, temp_file_name)
                     if os.path.exists(temp_file_path):
-                        os.remove(temp_file_path)
-
-                    with open(temp_file_path, "wb") as temp_file:
-                        print(3.5)
-                        #print(decrypted_data)
-                        temp_file.write(decrypted_data) # error here
-                        print(3.75)
-                        temp_file.seek(0)
-                        print(3.99)
-                        page = ExperimentMenuUI(root, temp_file.name, experiments_frame)
-                        print(1)
+                        page = ExperimentMenuUI(root, temp_file_name, experiments_frame)
                         page.raise_frame()
-                        print(4)
-                    password_prompt.destroy()
-                    print(5)
+                    else:
+                        with open(temp_file_path, "wb") as temp_file:
+                            temp_file.write(decrypted_data)
+                            temp_file.seek(0)
+                            page = ExperimentMenuUI(root, temp_file.name, experiments_frame)
+                            page.raise_frame()
+                        password_prompt.destroy()
 
                 except Exception as e:# pylint: disable= broad-exception-caught
-                    print(e)
                     CTkMessagebox(
                         message="Incorrect password",
                         title="Error",
@@ -77,6 +71,11 @@ def create_file():
     Navigates to the NewExperimentUI page.'''
     page = NewExperimentUI(root, experiments_frame)
     page.raise_frame()
+
+temp_folder_name = "Mouser"
+temp_folder_path = os.path.join(tempfile.gettempdir(), temp_folder_name)
+if os.path.exists(temp_folder_path):
+    shutil.rmtree(temp_folder_path)
 
 root = CTk()
 root.title("Mouser")
@@ -101,4 +100,6 @@ raise_frame(experiments_frame)
 root.grid_rowconfigure(0, weight=1)
 root.grid_columnconfigure(0, weight=1)
 
+
 root.mainloop()
+

--- a/main.py
+++ b/main.py
@@ -43,13 +43,21 @@ def open_file():
                         os.remove(temp_file_path)
 
                     with open(temp_file_path, "wb") as temp_file:
-                        temp_file.write(decrypted_data)
+                        print(3.5)
+                        #print(decrypted_data)
+                        temp_file.write(decrypted_data) # error here
+                        print(3.75)
                         temp_file.seek(0)
+                        print(3.99)
                         page = ExperimentMenuUI(root, temp_file.name, experiments_frame)
+                        print(1)
                         page.raise_frame()
+                        print(4)
                     password_prompt.destroy()
+                    print(5)
 
-                except Exception as _:# pylint: disable= broad-exception-caught
+                except Exception as e:# pylint: disable= broad-exception-caught
+                    print(e)
                     CTkMessagebox(
                         message="Incorrect password",
                         title="Error",


### PR DESCRIPTION
Fixes #168 

**What was changed?**

Nothing was changed currently, but problems were identified. There are two possible errors that could occur when trying to access protected experiment files:

- If the first time the password is incorrect when opening the file, then that means the file path that got passed to the password manager isn't byte, which gives error when trying to read from the file. However, I rarely encounter this error, and the next error is the main problem of this issue, so I put the possible error here in case someone else encounters this problem in the future and needs a reference.

- if the password is incorrect the second time a user tries to access the file after opening it for the first time, then it's the problem of the database of the previous temporary file hasn't been closed yet, which gives the error: "The process cannot access the file because it is being used by another process: 'C:\\Users\\\\_user_name_\\Local\\Temp\\Mouser\\test password_Protected.mouser'", to solve this problem, the database should be disconnected from the database after the user exit out of the protected file. However, I couldn't figure out the exact way to accomplish this task, so I use another method, which is to remove the directory containing the temporary file every time the mouser application starts.

**Why was it changed?**

  The error arose because whenever a protected file was opened, a temporary file with all method that the actual file would have is created in a temporary mouser directory, and the application would use that file instead of the actual file. This means that the application is creating duplicate files in the temporary directory, which takes up the memory of the PC. Therefore, the original approach to reduce the resources use was to check if a duplicate file already exists and if it does, the application will remove the file. However, every time the temporary file is created it is connected to the database, and there's no method that's currently implemented to disconnect a mouser file from the database when it's not being used by the mouser application. This makes it so that even if the user moves on to another mouser file, the database is still connected to the temporary file, and evoke the error when the application tries to remove it. 

**How was it changed?**
I added a check in main.py that checks if there's a "Mouser" directory in the AppData/Local/Temp, if there is, then the application will delete that directory. I also added a check so that if there's a temporary file already existed in the temporary directory, then there's no need to create a new temporary file and writes data to it since we can use the existing file.


