### PR TITLE
Changed experiment to name protected files as .pmouser files

### DIFF
--- a/experiment_pages/create_experiment/summary_ui.py
+++ b/experiment_pages/create_experiment/summary_ui.py
@@ -26,13 +26,13 @@ class CreateExperimentButton(CTkButton):
             self.experiment.save_to_database(directory)
             if self.experiment.get_password():
                 password = self.experiment.get_password()
-                file = directory + '/' + self.experiment.get_name() + '_Protected.mouser'
+                file = directory + '/' + self.experiment.get_name() + '.pmouser'
                 manager = PasswordManager(password)
                 decrypted_data = manager.decrypt_file(file)
                 temp_folder_name = "Mouser"
                 temp_folder_path = os.path.join(tempfile.gettempdir(), temp_folder_name)
                 os.makedirs(temp_folder_path, exist_ok=True)
-                temp_file_name = self.experiment.get_name() + '_Protected.mouser'
+                temp_file_name = self.experiment.get_name() + '.pmouser'
                 temp_file_path = os.path.join(temp_folder_path, temp_file_name)
                 if os.path.exists(temp_file_path):
                     os.remove(temp_file_path)

--- a/main.py
+++ b/main.py
@@ -6,12 +6,17 @@ from customtkinter import *
 from CTkMenuBar import *
 from CTkMessagebox import CTkMessagebox
 from shared.tk_models import *
+import shared.file_utils as file_utils
 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 from experiment_pages.create_experiment.new_experiment_ui import NewExperimentUI
 from experiment_pages.experiment.select_experiment_ui import ExperimentsUI
 from shared.password_utils import PasswordManager
 
 TEMP_FOLDER_NAME = "Mouser"
+TEMP_FILE_PATH = None
+
+CURRENT_FILE_PATH = None
+PASSWORD = None
 
 def open_file():
     '''Command for 'Open' option in menu bar.
@@ -19,7 +24,11 @@ def open_file():
     Opens a .mouser file
     '''
     file_path = askopenfilename(filetypes=[("Database files",".mouser .pmouser")])
+    print(file_path)
     if file_path:
+        global CURRENT_FILE_PATH 
+        CURRENT_FILE_PATH = file_path
+
         if ".pmouser" in file_path:
             password_prompt = CTkToplevel(root)
             password_prompt.title("Enter Password")
@@ -34,25 +43,18 @@ def open_file():
             def handle_password():
                 password = password_entry.get()
                 try:
-                    manager = PasswordManager(password)
-                    decrypted_data = manager.decrypt_file(file_path)
-                    TEMP_FOLDER_NAME = "Mouser"
-                    temp_folder_path = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
-                    os.makedirs(temp_folder_path, exist_ok=True)
-                    temp_file_name =  os.path.basename(file_path)
-                    temp_file_path = os.path.join(temp_folder_path, temp_file_name)
-                    if os.path.exists(temp_file_path):
-                        page = ExperimentMenuUI(root, temp_file_name, experiments_frame)
-                        page.raise_frame()
-                    else:
-                        with open(temp_file_path, "wb") as temp_file:
-                            temp_file.write(decrypted_data)
-                            temp_file.seek(0)
-                            page = ExperimentMenuUI(root, temp_file.name, experiments_frame)
-                            page.raise_frame()
-                        password_prompt.destroy()
 
-                except Exception as _:# pylint: disable= broad-exception-caught
+                    temp_file_path = file_utils.create_temp_from_encrypted(file_path, password)
+                    global PASSWORD
+                    PASSWORD = password
+                    if os.path.exists(temp_file_path):
+                        global TEMP_FILE_PATH
+                        TEMP_FILE_PATH = temp_file_path
+                        page = ExperimentMenuUI(root, temp_file_path, experiments_frame)
+                        page.raise_frame()
+
+                except Exception as e:# pylint: disable= broad-exception-caught
+                    print(e)
                     CTkMessagebox(
                         message="Incorrect password",
                         title="Error",
@@ -62,8 +64,12 @@ def open_file():
             password_button = CTkButton(password_prompt, text="OK", command=handle_password)
             password_button.pack()
         else:
-            page = ExperimentMenuUI(root, file_path, experiments_frame)
+            temp_file = file_utils.create_temp_copy(file_path)
+            global TEMP_FILE_PATH
+            TEMP_FILE_PATH = temp_file
+            page = ExperimentMenuUI(root, temp_file, experiments_frame)
             page.raise_frame()
+        
 
 # Command for 'New' option in menu bar
 def create_file():
@@ -72,6 +78,16 @@ def create_file():
     Navigates to the NewExperimentUI page.'''
     page = NewExperimentUI(root, experiments_frame)
     page.raise_frame()
+
+def save_file():
+    '''Command for the 'save file' option in menu bar.'''
+    print("Current", CURRENT_FILE_PATH)
+    print("Temp", TEMP_FILE_PATH)
+
+    if ".pmouser" in CURRENT_FILE_PATH:
+        file_utils.save_temp_to_encrypted(TEMP_FILE_PATH, CURRENT_FILE_PATH, PASSWORD)
+    else:
+        file_utils.save_temp_to_file(TEMP_FILE_PATH, CURRENT_FILE_PATH)
 
 TEMP_FOLDER_NAME = "Mouser"
 temp_folder_path = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
@@ -89,6 +105,7 @@ file_menu = menu_bar.add_cascade("File")
 file_dropdown = CustomDropdownMenu(widget=file_menu)
 file_dropdown.add_option(option="New", command = create_file)
 file_dropdown.add_option(option="Open", command = open_file)
+file_dropdown.add_option(option="Save", command = save_file)
 
 root.config(menu=menu_bar)
 

--- a/main.py
+++ b/main.py
@@ -18,9 +18,9 @@ def open_file():
 
     Opens a .mouser file
     '''
-    file_path = askopenfilename(filetypes=[("Database files","*.mouser")])
+    file_path = askopenfilename(filetypes=[("Database files",".mouser .pmouser")])
     if file_path:
-        if "Protected" in file_path:
+        if ".pmouser" in file_path:
             password_prompt = CTkToplevel(root)
             password_prompt.title("Enter Password")
             password_prompt.geometry("300x100")

--- a/shared/experiment.py
+++ b/shared/experiment.py
@@ -146,7 +146,7 @@ class Experiment():
     def save_to_database(self, directory: str):
         '''Saves experiment object to a file.'''
         if self.password:
-            file = directory + '/' + self.name + '_Protected.mouser'
+            file = directory + '/' + self.name + '.pmouser'
         else:
             file = directory + '/' + self.name + '.mouser'
         db = ExperimentDatabase(file)

--- a/shared/file_utils.py
+++ b/shared/file_utils.py
@@ -1,0 +1,63 @@
+import tempfile, os
+from shared.password_utils import PasswordManager
+
+
+TEMP_FOLDER_NAME = "Mouser"
+
+def create_temp_copy(filepath:str):
+    '''Creates a new temporary file and returns the file path of the temporary file.'''
+
+    temp_folder_path = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
+    os.makedirs(temp_folder_path, exist_ok=True)
+    temp_file_name =  os.path.basename(filepath)
+    temp_file_path = os.path.join(temp_folder_path, temp_file_name)
+
+    with open(filepath, 'rb') as file:
+        data = file.read()
+
+    with open(temp_file_path, 'wb') as file:
+        file.write(data)
+        file.seek(0)
+    
+    return temp_file_path
+
+def create_temp_from_encrypted(filepath:str, password:str):
+    '''Creates a new decrypted copy of a file.'''
+
+    print(filepath)
+    temp_folder_path = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
+    os.makedirs(temp_folder_path, exist_ok=True)
+    temp_file_name =  os.path.basename(filepath)
+    temp_file_path = os.path.join(temp_folder_path, temp_file_name)
+
+    manager = PasswordManager(password)
+
+    data = manager.decrypt_file(filepath)
+
+    with open(temp_file_path, 'wb') as file:
+        file.write(data)
+        file.seek(0)
+    
+    return temp_file_path
+
+
+def save_temp_to_file(temp_file_path: str, permanent_file_path: str):
+    '''Save data from temporary file to a permanent file'''
+    
+    with open(temp_file_path, 'rb') as temp_file:
+        data = temp_file.read()
+    
+    with open(permanent_file_path, 'wb') as file:
+        file.write(data)
+    
+def save_temp_to_encrypted(temp_file_path: str, permanent_file_path: str, password:str):
+    '''Save data from temporary file to an encrypted file.'''
+    manager = PasswordManager(password)
+    
+    manager.encrypt_file(temp_file_path)
+    with open(temp_file_path, 'rb') as encrypted:
+        data = encrypted.read()
+    
+    with open(permanent_file_path, 'wb') as file:
+        file.write(data)
+    

--- a/shared/file_utils.py
+++ b/shared/file_utils.py
@@ -1,4 +1,6 @@
-import tempfile, os
+'''Contains functions to create and save from temporary files.'''
+import tempfile
+import os
 from shared.password_utils import PasswordManager
 
 
@@ -18,7 +20,7 @@ def create_temp_copy(filepath:str):
     with open(temp_file_path, 'wb') as file:
         file.write(data)
         file.seek(0)
-    
+
     return temp_file_path
 
 def create_temp_from_encrypted(filepath:str, password:str):
@@ -37,27 +39,26 @@ def create_temp_from_encrypted(filepath:str, password:str):
     with open(temp_file_path, 'wb') as file:
         file.write(data)
         file.seek(0)
-    
+
     return temp_file_path
 
 
 def save_temp_to_file(temp_file_path: str, permanent_file_path: str):
     '''Save data from temporary file to a permanent file'''
-    
+
     with open(temp_file_path, 'rb') as temp_file:
         data = temp_file.read()
-    
+
     with open(permanent_file_path, 'wb') as file:
         file.write(data)
-    
+
 def save_temp_to_encrypted(temp_file_path: str, permanent_file_path: str, password:str):
     '''Save data from temporary file to an encrypted file.'''
     manager = PasswordManager(password)
-    
+
     manager.encrypt_file(temp_file_path)
     with open(temp_file_path, 'rb') as encrypted:
         data = encrypted.read()
     
     with open(permanent_file_path, 'wb') as file:
         file.write(data)
-    

--- a/shared/password_utils.py
+++ b/shared/password_utils.py
@@ -28,12 +28,13 @@ class PasswordManager:
             dbfile.write(self.encrypted_data)
 
     def decrypt_file(self, file_path):
-        '''Decrypts passed file.'''
+        '''returns the decrypted data of the passed file.'''
         try:
             with open(file_path, "rb") as file:
                 encrypted_data = file.read()
             decrypted_data = self.fernet.decrypt(encrypted_data)
             return decrypted_data
 
-        except Exception as _: # pylint: disable= broad-exception-caught
+        except Exception as e: # pylint: disable= broad-exception-caught
+            print(e)
             return False


### PR DESCRIPTION
Fixes #171 

**What was changed?**

Changed file creation and opening to use '.pmouser' as a marker of a protected mouser file instead of "_Protected"

Changed file opening such that both protected and unprotected files are opened as temporary files.

Added new option in the file menu called "save" which saves the data from the temp file to the permanent file.

**Why was it changed?**

The original configuration would cause errors if someone renamed a file. An unprotected file with "_Protected" in the name would be mistaken as a password protected file while a protected file without "_Protected" would be mistaken as a normal file.

**How was it changed?**

Changed the naming convention of a protected file to have the .pmouser file extension.

Added new file called "file_utils.py" which contains functions to both create temporary files and save from temp files to permanent files. main.py also now tracks the permanent file path, temp file path, and password of the given file as global variables.
