### PR TITLE
adjusting modules to reflect changes in serial port setting

### DIFF
--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -2,6 +2,7 @@
 import os
 from customtkinter import *
 from shared.tk_models import *
+from shared.serial_port_controller import SerialPortController
 from experiment_pages.experiment.data_collection_ui import DataCollectionUI
 from experiment_pages.experiment.data_analysis_ui import DataAnalysisUI
 from experiment_pages.experiment.map_rfid import MapRFIDPage
@@ -11,7 +12,7 @@ from experiment_pages.experiment.experiment_invest_ui import InvestigatorsUI
 
 class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
     '''Experiment Menu Page Frame'''
-    def __init__(self, parent: CTk, name: str, prev_page: ChangeableFrame = None): #pylint: disable= undefined-variable
+    def __init__(self, parent: CTk, name: str, prev_page: ChangeableFrame = None, controller: SerialPortController = None): #pylint: disable= undefined-variable
 
         #Get name of file from file path
         experiment_name = os.path.basename(name)
@@ -29,7 +30,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         self.data_page = DataCollectionUI(parent, self, name)
         self.analysis_page = DataAnalysisUI(parent, self)
         self.cage_page = CageConfigurationUI(name, parent, self)
-        self.rfid_page = MapRFIDPage(name, parent, self)
+        self.rfid_page = MapRFIDPage(name, parent, self, controller)
         self.invest_page = InvestigatorsUI(parent, self)
 
         button_size = 30

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -25,14 +25,17 @@ def play_sound_async(filename):
 
 class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
     '''Map RFID user interface and window.'''
-    def __init__(self, database, parent: CTk, previous_page: CTkFrame = None):
+    def __init__(self, database, parent: CTk, previous_page: CTkFrame = None, controller: SerialPortController = None):
 
         super().__init__(parent, "Map RFID", previous_page)
 
 
         file = database
         self.db = ExperimentDatabase(file)
-        self.serial_port_controller = SerialPortController()
+        if controller:
+            self.serial_port_controller = controller
+        else:
+            self.serial_port_controller = SerialPortController()
 
         self.animals = []
         self.animal_id = 1

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from CTkMenuBar import *
 from CTkMessagebox import CTkMessagebox
 from shared.serial_port_settings import SerialPortSetting
 from shared.tk_models import *
+from shared.serial_port_controller import *
 import shared.file_utils as file_utils
 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 from experiment_pages.create_experiment.new_experiment_ui import NewExperimentUI
@@ -21,6 +22,7 @@ TEMP_FILE_PATH = None
 
 CURRENT_FILE_PATH = None
 PASSWORD = None
+rfid_serial_port_controller = SerialPortController()
 
 #pylint: disable = global-statement
 def open_file():
@@ -87,7 +89,7 @@ def create_file():
 
 def open_serial_port_setting():
     '''opens the serial port setting page'''
-    SerialPortSetting("serial_port_preference.csv") # pylint: disable=unused-variable
+    SerialPortSetting("serial_port_preference.csv", rfid_serial_port_controller) # pylint: disable=unused-variable
 def save_file():
     '''Command for the 'save file' option in menu bar.'''
     print("Current", CURRENT_FILE_PATH)

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -97,3 +97,10 @@ class SerialPortController():
         '''Testing function for map_rfid serial port.'''
         message = rfid.encode()
         self.writer_port.write(message)
+
+    def update_setting(self):
+        # TODO: close the current reader port, open the reader port again from the new file
+        pass
+
+    def retrieve_setting(self, file_path):
+        pass

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -4,6 +4,7 @@ from os.path import isfile, join
 from csv import *
 from customtkinter import *
 from shared.tk_models import SettingPage
+from shared.serial_port_controller import *
 
 
 
@@ -12,7 +13,7 @@ class SerialPortSetting(SettingPage):
     '''a class that implements methods and functions 
     related to connecting serial port setting to the experiments '''
 
-    def __init__(self, preference = NONE):
+    def __init__(self, preference = NONE, controller: SerialPortController = NONE):
         ''' implement the constructor of the class object,
         initializing the tab_view page with summary page'''
 
@@ -23,6 +24,7 @@ class SerialPortSetting(SettingPage):
         self.configuration_name = StringVar(value="")
         self.current_configuration_name = StringVar(value="")
         self.preference_path = None
+        self.serial_port_controller = None
 
         self.baud_rate_var = StringVar(value="")
         self.parity_var = StringVar(value="")
@@ -30,6 +32,10 @@ class SerialPortSetting(SettingPage):
         self.data_bits_var = StringVar(value="")
         self.stop_bits_var = StringVar(value="")
         self.input_bype_var = StringVar(value="")
+
+        if controller:
+            self.serial_port_controller = SerialPortController()
+
         if preference:
             try:
                 self.preference_path = os.getcwd() + "\\settings\\serial ports\\preference\\" + preference
@@ -250,7 +256,8 @@ class SerialPortSetting(SettingPage):
             # give a error window that says preference_file not set up
             print("Preference file missing")
             pass
-
+        if self.serial_port_controller:
+            self.serial_port_controller.update_setting()
 
     def confirm_setting(self, f = None):
         '''select a configuration and use it as current serial


### PR DESCRIPTION
Fixes #issue_number

**What was changed?**

Main, serial port setting, serial port controller, experiment menu, and map rfid is changes so that map rfid, serial port setting, and experiment menu now accepts a serial port controller created in main.

**Why was it changed?**

It was changed because there's a need for serial port setting to connect to serial port controller so that whenever there's a change made to the setting of the serial port, it'll be reflected to the controller so that it'll take action to use the new setting. 

**How was it changed?**

To make the change possible, observer pattern is used such that whenever there's a change to the setting, serial port setting will call a function in the controller that change the current setting of serial port to the new setting.

**Screenshots that show the changes (if applicable):**
