### PR TITLE
switched actions to v4 from v2

### DIFF
--- a/.github/workflows/Pylint.yaml
+++ b/.github/workflows/Pylint.yaml
@@ -33,12 +33,7 @@ jobs:
                 echo "Processing $file"
               
                 pylint --disable=import-error,R,wildcard-import,unused-wildcard-import,attribute-defined-outside-init --max-line-length=115 --fail-under=9.0 $file || lint_failed="failed"
-                pylint_status=$?
                 
-                if [ $pylint_status -ne 0 ]; then
-                  echo "Linting failed for file: $file"
-                  lint_failed="failed"
-                fi
               done
               if [ "$lint_failed" = "failed" ]
               then

--- a/.github/workflows/Pylint.yaml
+++ b/.github/workflows/Pylint.yaml
@@ -29,8 +29,8 @@ jobs:
     - name: Analysing the code with pylint and handling exit code
       id: lint
       run: |
-              for file in $(git ls-files '*.py'); do
-                echo "Processing $file"
+              for file in $(git ls-files '*.py')
+              do
               
                 pylint --disable=import-error,R,wildcard-import,unused-wildcard-import,attribute-defined-outside-init --max-line-length=115 --fail-under=9.0 $file || lint_failed="failed"
                 

--- a/.github/workflows/Pylint.yaml
+++ b/.github/workflows/Pylint.yaml
@@ -29,10 +29,13 @@ jobs:
     - name: Analysing the code with pylint and handling exit code
       id: lint
       run: |
-              for file in $(git ls-files '*.py')
-              do
+              for file in $(git ls-files '*.py'); do
+                echo "Processing $file"
+              
                 pylint --disable=import-error,R,wildcard-import,unused-wildcard-import,attribute-defined-outside-init --max-line-length=115 --fail-under=9.0 $file || lint_failed="failed"
-                if [ $? -ne 0 ]; then
+                pylint_status=$?
+                
+                if [ $pylint_status -ne 0 ]; then
                   echo "Linting failed for file: $file"
                   lint_failed="failed"
                 fi

--- a/.github/workflows/Pylint.yaml
+++ b/.github/workflows/Pylint.yaml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: [3.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install PortAudio

--- a/.github/workflows/Pylint.yaml
+++ b/.github/workflows/Pylint.yaml
@@ -32,7 +32,7 @@ jobs:
               for file in $(git ls-files '*.py')
               do
                 pylint --disable=import-error,R,wildcard-import,unused-wildcard-import,attribute-defined-outside-init --max-line-length=115 --fail-under=9.0 $file || lint_failed="failed"
-                if [ $? -ne 0]; then
+                if [ $? -ne 0 ]; then
                   echo "Linting failed for file: $file"
                   lint_failed="failed"
                 fi

--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -14,8 +14,8 @@ jobs:
         os: ["windows-latest", "macos-latest"]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.11
       - run: brew install mysql pkg-config portaudio
@@ -32,7 +32,7 @@ jobs:
           robocopy images dist/main/images
           robocopy sounds dist/main/sounds
           ren dist\main\main.exe Mouser.exe
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Mouser_${{ matrix.os }}

--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-      - create-exe
+      - 219-executable-workflow-deprecated-version-fix
 
 jobs:
   build:

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -61,6 +61,10 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
 
         self.bind("<<FrameRaised>>", self.on_show_frame)
 
+# Assume buttons are enabled initially- This allows for them to be disabled before RFID Mapping is done
+        self.disable_buttons_if_needed()
+
+
     def raise_frame(self):
         self.on_show_frame()
         super().raise_frame()
@@ -126,6 +130,17 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         print(f"Number of animals mapped = {num_mapped}\n Number of total animals = {num_animals}")
 
         return (num_animals == num_mapped)
+    
+    def disable_buttons_if_needed(self):
+    # This method disables all buttons except for the Map RFID button until all specimens have an associated RFID
+        if self.all_rfid_mapped:
+            self.collection_button.configure(state="disabled")
+            self.analysis_button.configure(state="disabled")
+            self.group_button.configure(state="disabled")
+        else:
+            self.collection_button.configure(state="normal")
+            self.analysis_button.configure(state="normal")
+            self.group_button.configure(state="normal")
 
     def on_show_frame(self):
         button_state = DISABLED

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -133,7 +133,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
     
     def disable_buttons_if_needed(self):
     # This method disables all buttons except for the Map RFID button until all specimens have an associated RFID
-        if self.all_rfid_mapped:
+        if self.all_rfid_mapped():
             self.collection_button.configure(state="disabled")
             self.analysis_button.configure(state="disabled")
             self.group_button.configure(state="disabled")


### PR DESCRIPTION
Fixes #219 

**What was changed?**

GitHub Actions has removed support for its v2, so we have updated to v4.

**Why was it changed?**

The create-executable workflow was automatically failing due to this deprecation, and not actually running the workflow.
