### PR TITLE
Home Page UI Update (Issue #225)

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,7 @@ def open_file():
                         TEMP_FILE_PATH = temp_file_path
                         page = ExperimentMenuUI(root, temp_file_path, experiments_frame)
                         page.raise_frame()
+                        password_prompt.destroy()
 
                 except Exception as e:# pylint: disable= broad-exception-caught
                     print(e)
@@ -108,9 +109,14 @@ temp_folder_path = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
 if os.path.exists(temp_folder_path):
     shutil.rmtree(temp_folder_path)
 
+
 root = CTk()
+
+screen_width = root.winfo_screenwidth()
+screen_height = root.winfo_screenheight()
+
 root.title("Mouser")
-root.geometry('900x600')
+root.geometry(f"{screen_width}x{screen_height}+0+0")
 root.minsize(900,600)
 
 # Adds menu bar to root and binds the function to file_menu
@@ -132,16 +138,27 @@ main_frame = MouserPage(root, "Mouser")
 
 experiments_frame = ExperimentsUI(root, main_frame)
 mouse_image = CTkImage(light_image=Image.open("./shared/images/MouseLogo.png"), size=(550, 200))
-#mouse_button = CTkButton(main_frame, image=mouse_image, command=on_mouse_button_click)
-#mouse_button.grid(row=1, column=0, pady=(20, 10))
 mouse_label = CTkLabel(experiments_frame, image=mouse_image)
 mouse_label.grid(row=1, column=0, pady=(20, 10))
-create_nav_button(
-    experiments_frame,
-    ("Welcome to Mouser! Please click the File Drop Down option in the top "
-     "left to create or open a new Experiment.\n"),
-    mouse_image, experiments_frame, 0.5, 0.33
-)
+
+welcome_frame = CTkFrame(experiments_frame)
+welcome_frame.place(relx=0.5, rely=0.33, anchor="center")
+
+# Create and place the image
+image_label = CTkLabel(welcome_frame, image=mouse_image, text="")
+image_label.pack(pady=(20, 10))
+
+# Create and place the welcome text
+welcome_text = "Welcome to Mouser!"
+text_label = CTkLabel(welcome_frame, text=welcome_text, wraplength=400, font=("Georgia", 32))
+text_label.pack(padx=20, pady=10)
+
+new_file_button = CTkButton(welcome_frame, text="New Experiment", command=create_file, width=200, height=50)
+open_file_button = CTkButton(welcome_frame, text="Open Experiment", command=open_file, width=200, height=50)
+
+new_file_button.pack(pady=(10, 5), padx=20, fill='x', expand=True)
+open_file_button.pack(pady=(5, 10), padx=20, fill='x', expand=True)
+
 raise_frame(experiments_frame)
 root.grid_rowconfigure(0, weight=1)
 root.grid_columnconfigure(0, weight=1)


### PR DESCRIPTION
Fixes #225 

**What was changed?**

- Got rid of the useless button that originally held the Mouser logo and instead opted to change it to 2 separate image and text labels respectively. 
- Two buttons were added to the home screen, "New Experiment" and "Open Experiment", they simply mirror the usage of the file > "New Experiment"/"Open Experiment".
- Changed the window size to open to the users display dimensions upon startup. 
- Solved the quick issue of the password box not closing when the inputted password is correct.

**Why was it changed?**

- Removed the original Mouser logo setup because I believe that (A) it was a useless button so there was no need for it, and (B) The fact that it highlighted when hovered could create confusion for users.
- Added the two buttons on the home screen because Mouser deals with experiments that are supposed to be quick. Why click "File > New Experiment" when there can just be a button on the home screen? The lab techs are working with viruses, the quicker they can do these experiments, the better.
- Changed the window size on startup simply out of preference, I just think it looks cleaner and a nice touch.
- Password box didn't originally close when the password was correctly inputted. This creates unnecessary button click, that again, the lab techs don't want. 

**How was it changed?**

- For the Mouser home screen logo, I simply split the image and text that were once wrapped into a dummy button and just made them two separate entities. Both became CTkLabels.
- For the "New Experiment" and "Load Experiment" buttons, I simply copied the functionality of the "File" dropdown bar options for "New Experiment" and "Load Experiment" and made home screen buttons out of them. I decided to keep the drop down bar for convenience sake, it looks nice when the other pages also have it so I kept it.
- The window dimensions were taken from a given CTk function that can scan the dimensions of the users display. I used that information to plug it into the startup dimension sizes.
- The password box termination just needed to call a .destroy() after the password was proven to be correct.

**Screenshots that show the changes (if applicable):**
<img width="1440" alt="Screenshot 2024-09-27 at 5 21 57 PM" src="https://github.com/user-attachments/assets/e27b4cb2-8010-416b-8c0d-42202ab667dc">
