### PR TITLE
Changes to map_rfid.py to Fix Issue #233

### DIFF
--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -15,6 +15,8 @@ from shared.serial_port_controller import SerialPortController
 from databases.experiment_database import ExperimentDatabase
 from shared.audio import AudioManager
 
+import shared.file_utils as file_utils
+
 def get_random_rfid():
     '''Returns a simulated rfid number'''
     return random.randint(1000000, 9999999)
@@ -29,6 +31,8 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
         super().__init__(parent, "Map RFID", previous_page)
 
+        # Store the parent reference
+        self.parent = parent
 
         file = database
         self.db = ExperimentDatabase(file)
@@ -273,7 +277,19 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         if len(self.animals) != self.db.get_number_animals():
             self.raise_warning(warning_message= 'Not all animals have been mapped to RFIDs')
         else:
-            self.menu_button.navigate() #pylint: disable= undefined-variable
+            # Get the current file path before closing
+            current_file = self.db.db_file  # Changed from file_path to db_file
+            # Close the current database connection
+            self.close_connection()
+            
+            # Local import to avoid circular dependency
+            from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
+        
+            # Create new ExperimentMenuUI instance with the same file
+            temp_file = file_utils.create_temp_copy(current_file)
+            new_page = ExperimentMenuUI(self.parent, temp_file, self.menu_page)
+            new_page.raise_frame()
+
 
     def close_connection(self):
         '''Closes database file.'''


### PR DESCRIPTION
This file forces the program to open the recently created file after all RFIDs have been mapped. This fixes issue #233.

Fixes #233 

**What was changed?**

map_rfid.py was changed to allow to go straight from experiment creation, to rfid mapping, to data collection, without having to open or close any files. 

**Why was it changed?**

The issue was that if a new experiment was created, the user would have to reopen it after mapping rfids but before being able to utilize the data collection page. 

**How was it changed?**

map_rfid.py now stores relevant information locally, such as the parent experiment menu frame and the local path where the newly created experiment is stored. From there, when the user hits the back to menu button, assuming all rfids have been successfully mapped, it then closes and reopens the file back to the experiment menu page. From there, the user can directly navigate to the data collection page without issue. 

**Screenshots that show the changes (if applicable):**
