### PR TITLE
Data input is now Touchless

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -224,12 +224,12 @@ class ChangeMeasurementsDialog():
                 errors += 1
         if errors == 0:
             self.error_text.place_forget()
-            self.submit_button["state"] = "normal"
+            # self.submit_button["state"] = "normal"
 
     def show_error(self):
         '''Displays an error window.'''
         self.error_text.place(relx=0.5, rely=0.85, anchor=CENTER)
-        self.submit_button["state"] = "disabled"
+        # self.submit_button["state"] = "disabled"
         AudioManager.play(filepath="shared/sounds/error.wav")
 
     def get_all_values(self):


### PR DESCRIPTION
Fixes #249 

**What was changed?**

Data from serial devices can now be input without touching the keyboard at all (with exception to sim mode, but that doesn't matter to lab techs).

**Why was it changed?**

Our client doesn't want to have to hit a submit button to input data once it's passed to machine. It is unsafe and innefficient.

**How was it changed?**

Created a method that basically just automates the function of the submit button. Once the data handler receives data, it calls the finish method that the submit button used to call and closes out the entry box.