### PR TITLE
RFID No Longer Mandatory for Experiment Menu Page

### DIFF
--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -428,6 +428,12 @@ class ExperimentDatabase:
         self._c.execute("SELECT rfid FROM animal_rfid")
         return self._c.fetchall()
 
+    def experiment_uses_rfid(self):
+        self._c.execute("SELECT uses_rfid FROM experiment")
+        do_we_use_rfid = self._c.fetchone()[0]  # Fetch the first result and get the integer value
+        return do_we_use_rfid
+        
+
     def get_all_experiment_info(self):
         '''Prints all experiment info to terminal.'''
         self._c.execute("SELECT name, species, uses_rfid, num_animals, num_groups, cage_max FROM experiment")

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -37,7 +37,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
             self.rfid_page = MapRFIDPage(name, parent, self, controller)
         self.invest_page = InvestigatorsUI(parent, self)
 
-        button_size = 40
+        button_size = 30
 
 
         self.collection_button = CTkButton(main_frame, text='Data Collection', width=button_size,
@@ -51,10 +51,10 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         self.rfid_button = CTkButton(main_frame, text='Map RFID', width=button_size,
                                 command=  self.rfid_page.raise_frame)
 
-        self.collection_button.grid(row=0, column=0, ipady=15, ipadx=15, pady=10, padx=10)
-        self.analysis_button.grid(row=1, column=0, ipady=15, ipadx=15, pady=10, padx=10)
-        self.group_button.grid(row=2, column=0, ipady=15, ipadx=15, pady=10, padx=10)
-        self.rfid_button.grid(row=3, column=0, ipady=15, ipadx=15, pady=10, padx=10)
+        self.collection_button.grid(row=0, column=0, ipady=10, ipadx=10, pady=10, padx=10)
+        self.analysis_button.grid(row=1, column=0, ipady=10, ipadx=10, pady=10, padx=10)
+        self.group_button.grid(row=2, column=0, ipady=10, ipadx=10, pady=10, padx=10)
+        self.rfid_button.grid(row=3, column=0, ipady=10, ipadx=10, pady=10, padx=10)
 
         if self.menu_button:
             self.menu_button.destroy()
@@ -73,7 +73,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         '''Raises warning frame for deleting experiment.'''
         message = CTk()
         message.title("WARNING")
-        message.geometry('750x550')
+        message.geometry('300x100')
         message.resizable(False, False)
 
         label1 = CTkLabel(message, text='This will delete the experiment and all its data')
@@ -134,14 +134,17 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
     def disable_buttons_if_needed(self):
     # This method disables all buttons except for the Map RFID button until all specimens have an associated RFID
         self.group_button.configure(state="normal")
-        if not self.all_rfid_mapped():
-            self.collection_button.configure(state="disabled")
-            self.analysis_button.configure(state="disabled")
-            self.group_button.configure(state="disabled")
+        if self.experiment.experiment_uses_rfid() == 1:
+            if not self.all_rfid_mapped():
+                self.collection_button.configure(state="disabled")
+                self.analysis_button.configure(state="disabled")
+                self.group_button.configure(state="disabled")
+            else:
+                self.collection_button.configure(state="normal")
+                self.analysis_button.configure(state="normal")
+                self.group_button.configure(state="normal")
         else:
-            self.collection_button.configure(state="normal")
-            self.analysis_button.configure(state="normal")
-            self.group_button.configure(state="normal")
+            self.rfid_button.configure(state="disabled")        
 
 
     def on_show_frame(self):

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -37,7 +37,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
             self.rfid_page = MapRFIDPage(name, parent, self, controller)
         self.invest_page = InvestigatorsUI(parent, self)
 
-        button_size = 30
+        button_size = 40
 
 
         self.collection_button = CTkButton(main_frame, text='Data Collection', width=button_size,
@@ -51,10 +51,10 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         self.rfid_button = CTkButton(main_frame, text='Map RFID', width=button_size,
                                 command=  self.rfid_page.raise_frame)
 
-        self.collection_button.grid(row=0, column=0, ipady=10, ipadx=10, pady=10, padx=10)
-        self.analysis_button.grid(row=1, column=0, ipady=10, ipadx=10, pady=10, padx=10)
-        self.group_button.grid(row=2, column=0, ipady=10, ipadx=10, pady=10, padx=10)
-        self.rfid_button.grid(row=3, column=0, ipady=10, ipadx=10, pady=10, padx=10)
+        self.collection_button.grid(row=0, column=0, ipady=15, ipadx=15, pady=10, padx=10)
+        self.analysis_button.grid(row=1, column=0, ipady=15, ipadx=15, pady=10, padx=10)
+        self.group_button.grid(row=2, column=0, ipady=15, ipadx=15, pady=10, padx=10)
+        self.rfid_button.grid(row=3, column=0, ipady=15, ipadx=15, pady=10, padx=10)
 
         if self.menu_button:
             self.menu_button.destroy()
@@ -73,7 +73,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         '''Raises warning frame for deleting experiment.'''
         message = CTk()
         message.title("WARNING")
-        message.geometry('300x100')
+        message.geometry('750x550')
         message.resizable(False, False)
 
         label1 = CTkLabel(message, text='This will delete the experiment and all its data')


### PR DESCRIPTION
Fixes issue raised by Client 

NOTE: At present, this fix only applies to the main Experiment Menu Page. Data collection still needs to be updated. 

**What was changed?**

The code has been modified to check whether RFIDs are flagged as being used for this experiment to disable the other buttons if needed. It also disables the RFID button in the case where the RFID is flagged as not being used. 

**Why was it changed?**

The Experiment Menu page now checks whether the experiment uses RFID and disables buttons accordingly per request from the client. 

**How was it changed?**

The Experiment menu page now checks within its disable buttons if needed method whether RFID is flagged as being used for this experiment. If it is being used, it continues as normal. If it is not being used, it disables the RFID button so there is confusion. It does this by calling a newly defined method within the experiment database that calls the uses_rfid int value and checks if it is 1 or 0, yes or no respectively. 

