### PR TITLE
Changes to Save Function to Add Timestamps 

### DIFF
--- a/shared/file_utils.py
+++ b/shared/file_utils.py
@@ -2,6 +2,7 @@
 import tempfile
 import os
 from shared.password_utils import PasswordManager
+from datetime import datetime
 
 
 TEMP_FOLDER_NAME = "Mouser"
@@ -47,10 +48,21 @@ def create_temp_from_encrypted(filepath:str, password:str):
 
 
 def save_temp_to_file(temp_file_path: str, permanent_file_path: str):
-    '''Save data from temporary file to a permanent file'''
+    '''
+    Save data from temporary file to a permanent file.
+    Automatically appends a timestamp to the filename before the extension.
+    '''
     # Ensure paths are absolute and properly resolved
     temp_file_path = os.path.abspath(temp_file_path)
     permanent_file_path = os.path.abspath(permanent_file_path)
+
+    # Split the path into base and extension
+    base, ext = os.path.splitext(permanent_file_path)
+    # Take only the part before the first underscore if it exists
+    base = base.split('_')[0]
+    # Add timestamp before the extension
+    timestamp_str = datetime.now().strftime("_%Y%m%d_%H%M%S")
+    permanent_file_path = f"{base}{timestamp_str}{ext}"
 
     with open(temp_file_path, 'rb') as temp_file:
         data = temp_file.read()
@@ -63,6 +75,14 @@ def save_temp_to_encrypted(temp_file_path: str, permanent_file_path: str, passwo
     # Ensure paths are absolute and properly resolved
     temp_file_path = os.path.abspath(temp_file_path)
     permanent_file_path = os.path.abspath(permanent_file_path)
+    
+    # Split the path into base and extension
+    base, ext = os.path.splitext(permanent_file_path)
+    # Take only the part before the first underscore if it exists
+    base = base.split('_')[0]
+    # Add timestamp before the extension
+    timestamp_str = datetime.now().strftime("_%Y%m%d_%H%M%S")
+    permanent_file_path = f"{base}{timestamp_str}{ext}"
     
     manager = PasswordManager(password)
 


### PR DESCRIPTION
Fixes #262

**What was changed?**

Inside the shared folder, the file utilities have been updated to better reflect the clients needs. Now, whenever the (existing file) is being saved, it is now saved with the experiment name followed by a timestamp in the file name. NOTE: This does not add a timestamp to the experiment upon creation. This functionality could be implemented upon request, but I am operating under the assumption that the creation of the experiment itself does not need a timestamp added to the file. 

**Why was it changed?**

This was changed to reflect the needs of the client, who are working in a system that needs both iterative saves and a proper understanding of when all data points were saved. This PR is part of a larger enhancement being worked on currently, the parent of Issue 262 for proper automatic iterative saves. 

**How was it changed?**

Inside both save functions (for .mouser and .pmouser files), the name of the experiment is collected and a timestamp is added to it after an underscore. So if the file name was "experiment1.mouser" it would then be "experiment1_20250131_105835.mouser". Before this file has this timestamp added to it, the name is stripped down to only the string before the first underscore in the file name. This means that if the open file already has a timestamp added on, it is removed and the new one is added in its place. This change is backwards compatible with all currently existing mouser files, as it simply changes the name of a file as it is saved. 

NOTE: The files changed looks bad because of an additional import at the top, datetime. This is necessary for accurate automatic date/time retrieval. 

This change is compatible with both MacOS and Windows, provided no illegal characters are in the filename. But that was already a compatibility requirement. 

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/2ea93a0e-ce0a-4c4b-93b3-3e03adacaa1f)

