### PR TITLE
Multiple Device Integration

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -193,7 +193,7 @@ class ChangeMeasurementsDialog():
                 entry.focus()
 
                 # Start data handling in a separate thread
-                data_handler = SerialDataHandler()
+                data_handler = SerialDataHandler("device")
                 data_thread = threading.Thread(target=data_handler.start)
                 data_thread.start()
 

--- a/experiment_pages/experiment/test_screen.py
+++ b/experiment_pages/experiment/test_screen.py
@@ -8,8 +8,9 @@ from shared.serial_handler import SerialDataHandler
 
 class TestScreen(CTkToplevel):
     '''Screen for testing functionality of RFID Readers and Serial Devices.'''
-    def __init__(self, parent: CTk, prev_page: CTkFrame = None):
+    def __init__(self, parent: CTk):
         super().__init__(parent)
+
         self.title("Test Screen")
         self.geometry("600x500")
 
@@ -28,7 +29,7 @@ class TestScreen(CTkToplevel):
         # Separate sections for RFID Readers and Serial Devices
         self.setup_rfid_section()
         self.setup_device_section()
-    
+
     def setup_rfid_section(self):
         '''Set up RFID Reader testing section.'''
         rfid_label = CTkLabel(self, text="RFID Reader", font=("Arial", 16, "bold"))
@@ -66,9 +67,8 @@ class TestScreen(CTkToplevel):
 
             reading_label = CTkLabel(self, text="-----", padx=10, pady=5)
             reading_label.grid(row=index, column=2, sticky="ew")
-            
-            self.reading_labels[com_port] = reading_label
 
+            self.reading_labels[com_port] = reading_label
 
     def test_device(self, com_port):
         '''Placeholder function to test serial devices'''
@@ -85,21 +85,21 @@ class TestScreen(CTkToplevel):
                 time.sleep(0.5)  # Wait a bit for data to arrive
                 if len(data_handler.received_data) > 0:
                     received_data = data_handler.get_stored_data()
-                    
+
                     # Ensure UI update runs in the main thread
                     self.after(0, lambda: self.reading_labels[com_port].configure(text=received_data))
 
                     data_handler.stop()
                     print(f"Received data: {received_data}")
                     return
-                
+
                 retries -= 1  # Decrease retries count
 
             print("No data received after retries. Stopping.")
 
         # Run in a background thread
         threading.Thread(target=check_for_data, daemon=True).start()
-    
+
     def test_reader(self, com_port):
         '''Function to test serial device reading.'''
         print(f"Testing serial device on {com_port}...")
@@ -115,14 +115,14 @@ class TestScreen(CTkToplevel):
                 time.sleep(0.5)  # Wait a bit for data to arrive
                 if len(data_handler.received_data) > 0:
                     received_data = data_handler.get_stored_data()
-                    
+
                     # Ensure UI update runs in the main thread
                     self.after(0, lambda: self.reading_labels[com_port].configure(text=received_data))
 
                     data_handler.stop()
                     print(f"Received data: {received_data}")
                     return
-                
+
                 retries -= 1  # Decrease retries count
 
             print("No data received after retries. Stopping.")

--- a/experiment_pages/experiment/test_screen.py
+++ b/experiment_pages/experiment/test_screen.py
@@ -1,0 +1,94 @@
+import os
+from customtkinter import *
+from shared.tk_models import *
+from shared.serial_handler import SerialDataHandler
+import threading
+
+class TestScreen(MouserPage):
+    '''Test Screen UI'''
+    def __init__(self, parent: CTk, prev_page: CTkFrame = None):
+        super().__init__(parent, "Test Screen", prev_page)
+        
+        # Dictionary to track reading labels
+        self.reading_labels = {}
+
+        # Create the main frame
+        main_frame = CTkFrame(self, corner_radius=15)
+        main_frame.grid(row=0, column=0, sticky="nsew")
+        main_frame.place(relx=0.3, rely=0.2, relwidth=0.4, relheight=0.75)
+
+        # Add a title label
+        title_label = CTkLabel(
+            main_frame, 
+            text="Test Screen", 
+            font=("Arial", 22, "bold"),  
+            pady=20
+        )
+        title_label.grid(row=0, column=0, columnspan=4, padx=20, pady=20)
+
+        # Header Row
+        headers = ["Test", "COM Port", "Device Name", "Reading"]
+        for col, header in enumerate(headers):
+            header_label = CTkLabel(main_frame, text=header, font=("Arial", 14, "bold"), padx=10, pady=5)
+            header_label.grid(row=1, column=col, padx=10, pady=5, sticky="ew")
+
+        # Read preferred devices (COM folders)
+        preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference")
+        preferred_devices = [d for d in os.listdir(preference_dir) if os.path.isdir(os.path.join(preference_dir, d))]
+
+        for index, com_port in enumerate(preferred_devices, start=2):
+            config_path = os.path.join(preference_dir, com_port, "preferred_config.txt")
+            rfid_path = os.path.join(preference_dir, com_port, "rfid_config.txt")
+            device_name = "Unknown"
+
+            if os.path.exists(config_path):
+                with open(config_path, "r") as file:
+                    device_name = file.readline().strip()
+
+            elif os.path.exists(rfid_path):
+                device_name = "RFID Reader"
+
+            # Test Button
+            test_button = CTkButton(main_frame, text="Test", command=lambda p=com_port: self.test_serial(p))
+            test_button.grid(row=index, column=0, padx=10, pady=5, sticky="ew")
+
+            # COM Port Label
+            com_label = CTkLabel(main_frame, text=com_port, padx=10, pady=5)
+            com_label.grid(row=index, column=1, sticky="ew")
+
+            # Device Name Label
+            device_label = CTkLabel(main_frame, text=device_name, padx=10, pady=5)
+            device_label.grid(row=index, column=2, sticky="ew")
+
+            # Default Reading Placeholder
+            reading_label = CTkLabel(main_frame, text="-----", padx=10, pady=5)
+            reading_label.grid(row=index, column=3, sticky="ew")
+
+            # Store reference to label for later updates
+            self.reading_labels[com_port] = reading_label
+
+    def test_serial(self, com_port):
+        '''Placeholder function to test serial devices'''
+        print(f"Testing serial device on {com_port}...")
+
+        # Placeholder for actual serial reading logic
+        test_value = "123.45"  # Replace with actual reading
+        data_handler = SerialDataHandler("device")
+        data_thread = threading.Thread(target=data_handler.start)
+        data_thread.start()
+
+        # Automated handling of data input
+        def check_for_data():
+            while True:
+                if len(data_handler.received_data) >= 2:  # Customize condition
+                    received_data = data_handler.get_stored_data()
+                    self.reading_labels[com_port].configure(text=received_data)
+                    data_handler.stop()
+                    self.finish()  # Automatically call the finish method
+                    break
+
+        threading.Thread(target=check_for_data, daemon=True).start()
+
+        # Update corresponding label
+        if com_port in self.reading_labels:
+            self.reading_labels[com_port].configure(text=test_value)

--- a/experiment_pages/experiment/test_screen.py
+++ b/experiment_pages/experiment/test_screen.py
@@ -1,11 +1,13 @@
+'''Screen for testing functionality of RFID Readers and Serial Devices.'''
 import os
 import time
+import threading
 from customtkinter import *
 from shared.tk_models import *
 from shared.serial_handler import SerialDataHandler
-import threading
 
 class TestScreen(CTkToplevel):
+    '''Screen for testing functionality of RFID Readers and Serial Devices.'''
     def __init__(self, parent: CTk, prev_page: CTkFrame = None):
         super().__init__(parent)
         self.title("Test Screen")
@@ -16,9 +18,9 @@ class TestScreen(CTkToplevel):
 
         # Add a title label
         title_label = CTkLabel(
-            self, 
-            text="Test Screen", 
-            font=("Arial", 22, "bold"),  
+            self,
+            text="Test Screen",
+            font=("Arial", 22, "bold"),
             pady=20
         )
         title_label.grid(row=0, column=0, columnspan=4, padx=20, pady=20)
@@ -27,10 +29,9 @@ class TestScreen(CTkToplevel):
         self.setup_rfid_section()
         self.setup_device_section()
     
-    '''Test Screen UI'''
     def setup_rfid_section(self):
         '''Set up RFID Reader testing section.'''
-        rfid_label = CTkLabel(self, text="RFID Readers", font=("Arial", 16, "bold"))
+        rfid_label = CTkLabel(self, text="RFID Reader", font=("Arial", 16, "bold"))
         rfid_label.grid(row=1, column=0, columnspan=2, pady=10)
 
         preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference")
@@ -50,7 +51,7 @@ class TestScreen(CTkToplevel):
 
     def setup_device_section(self):
         '''Set up Serial Device testing section.'''
-        device_label = CTkLabel(self, text="Serial Devices", font=("Arial", 16, "bold"))
+        device_label = CTkLabel(self, text="Serial Device", font=("Arial", 16, "bold"))
         device_label.grid(row=10, column=0, columnspan=2, pady=10)
 
         preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference")
@@ -128,7 +129,3 @@ class TestScreen(CTkToplevel):
 
         # Run in a background thread
         threading.Thread(target=check_for_data, daemon=True).start()
-
-        # Update corresponding label
-        if com_port in self.reading_labels:
-            self.reading_labels[com_port].configure(text=test_value)

--- a/main.py
+++ b/main.py
@@ -33,20 +33,7 @@ def get_resource_path(relative_path):
         print(f"Error accessing resource: {relative_path}")
         raise e
 
-
-
-
-
-# Ensure we are passing only the correct path
-csv_file_path = get_resource_path("settings/serial ports/serial_port_preference.csv")
-csv_file_path = os.path.normpath(csv_file_path)
-print(f"CSV file path: {csv_file_path}")  # Debugging: print the path to verify it's correct
-
-rfid_serial_port_controller = SerialPortController(csv_file_path)
-
-
-
-
+rfid_serial_port_controller = SerialPortController("reader")
 
 TEMP_FOLDER_NAME = "Mouser"
 TEMP_FILE_PATH = None
@@ -119,12 +106,13 @@ def create_file():
 
 def open_test():
     '''Command for 'Test Serials' button in the welcome screen.'''
-    page = TestScreen(root, experiments_frame)
-    page.raise_frame()
+    global test_screen_instance  # Store reference so it isn't garbage collected
+    test_screen_instance = TestScreen(root)
+    test_screen_instance.grab_set()
 
 def open_serial_port_setting():
     '''opens the serial port setting page'''
-    SerialPortSetting("serial_port_preference.csv", rfid_serial_port_controller) # pylint: disable=unused-variable
+    SerialPortSetting("device", rfid_serial_port_controller) # pylint: disable=unused-variable
 def save_file():
     '''Command for the 'save file' option in menu bar.'''
     print("Current", CURRENT_FILE_PATH)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-'''Main functionality of Program.'''
+'''Main functionality of Program. Main Screen!'''
 import os
 import shutil
 import tempfile

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import shared.file_utils as file_utils
 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 from experiment_pages.create_experiment.new_experiment_ui import NewExperimentUI
 from experiment_pages.experiment.select_experiment_ui import ExperimentsUI
+from experiment_pages.experiment.test_screen import TestScreen
 
 # Function to resolve resource paths (must be defined before usage)
 def get_resource_path(relative_path):
@@ -116,6 +117,10 @@ def create_file():
     page = NewExperimentUI(root, experiments_frame)
     page.raise_frame()
 
+def open_test():
+    '''Command for 'Test Serials' button in the welcome screen.'''
+    page = TestScreen(root, experiments_frame)
+    page.raise_frame()
 
 def open_serial_port_setting():
     '''opens the serial port setting page'''
@@ -185,9 +190,11 @@ text_label.pack(padx=20, pady=10)
 
 new_file_button = CTkButton(welcome_frame, text="New Experiment", command=create_file, width=200, height=50)
 open_file_button = CTkButton(welcome_frame, text="Open Experiment", command=open_file, width=200, height=50)
+test_screen_button = CTkButton(welcome_frame, text="Test Serials", command= open_test, width=200, height=50)
 
 new_file_button.pack(pady=(10, 5), padx=20, fill='x', expand=True)
 open_file_button.pack(pady=(5, 10), padx=20, fill='x', expand=True)
+test_screen_button.pack(pady=(5, 10), padx=20, fill='x', expand=True)
 
 raise_frame(experiments_frame)
 root.grid_rowconfigure(0, weight=1)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-'''Main functionality of Program. Main Screen!'''
+'''Main functionality of Program.'''
 import os
 import shutil
 import tempfile

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 import sys
-import os
 from tkinter.filedialog import *
 from PIL import Image
 from customtkinter import *
@@ -106,7 +105,7 @@ def create_file():
 
 def open_test():
     '''Command for 'Test Serials' button in the welcome screen.'''
-    global test_screen_instance  # Store reference so it isn't garbage collected
+    
     test_screen_instance = TestScreen(root)
     test_screen_instance.grab_set()
 
@@ -172,8 +171,7 @@ image_label = CTkLabel(welcome_frame, image=mouse_image, text="")
 image_label.pack(pady=(20, 10))
 
 # Create and place the welcome text
-welcome_text = "Welcome to Mouser!"
-text_label = CTkLabel(welcome_frame, text=welcome_text, wraplength=400, font=("Georgia", 32))
+text_label = CTkLabel(welcome_frame, text="Welcome to Mouser!", wraplength=400, font=("Georgia", 32))
 text_label.pack(padx=20, pady=10)
 
 new_file_button = CTkButton(welcome_frame, text="New Experiment", command=create_file, width=200, height=50)

--- a/settings/serial ports/preference/device/preferred_config.txt
+++ b/settings/serial ports/preference/device/preferred_config.txt
@@ -1,0 +1,1 @@
+Caliper.csv

--- a/settings/serial ports/preference/reader/rfid_config.txt
+++ b/settings/serial ports/preference/reader/rfid_config.txt
@@ -1,0 +1,1 @@
+test1.csv

--- a/settings/serial ports/preference/reader/rfid_config.txt
+++ b/settings/serial ports/preference/reader/rfid_config.txt
@@ -1,1 +1,1 @@
-test1.csv
+rfid_reader.csv

--- a/settings/serial ports/preference/serial_port_preference.csv
+++ b/settings/serial ports/preference/serial_port_preference.csv
@@ -1,1 +1,0 @@
-Caliper.csv

--- a/settings/serial ports/rfid_reader.csv
+++ b/settings/serial ports/rfid_reader.csv
@@ -1,0 +1,1 @@
+9600,None,None,Eight,1,Text,COM1

--- a/settings/serial ports/rfid_reader2.csv
+++ b/settings/serial ports/rfid_reader2.csv
@@ -1,0 +1,1 @@
+9600,None,None,Eight,1,Text,COM1

--- a/settings/serial ports/test_config.csv
+++ b/settings/serial ports/test_config.csv
@@ -1,0 +1,1 @@
+9600,None,None,Eight,1,Binary,COM3

--- a/settings/serial ports/test_reader.csv
+++ b/settings/serial ports/test_reader.csv
@@ -1,0 +1,1 @@
+9600,None,None,Eight,1,Text,COM1

--- a/shared/serial_handler.py
+++ b/shared/serial_handler.py
@@ -4,9 +4,10 @@ from shared.serial_listener import SerialReader  # Adjust this to your actual im
 
 class SerialDataHandler:
     '''Class to handle storing received data.'''
-    def __init__(self):
+    def __init__(self, port=None):
         # Initialize SerialReader and an empty list to store the data
-        self.reader = SerialReader(timeout=1)
+        print(f"Initializing SerialDataHandler with port: {port}")
+        self.reader = SerialReader(timeout=1, port=port)
         self.received_data = []
 
     def poll_serial_data(self):

--- a/shared/serial_listener.py
+++ b/shared/serial_listener.py
@@ -12,13 +12,9 @@ class SerialReader:
         self.timeout = timeout
         self.data_queue = Queue()   # A queue to hold the incoming data from the serial port
         self.running = True         # Flag to control the thread
-        self.device_file = self.find_device_config(port)
-        if not self.device_file:
-            print(f"ERROR: No configuration file found for {port}.")
-            self.running = False
-            return
-        self.port_controller = SerialPortController(self.device_file)
-        self.settings = self.port_controller.retrieve_setting(self.device_file)
+        self.port_controller = SerialPortController(port)
+        self.settings = self.port_controller.retrieve_setting(port)
+        print(f"Settings: {self.settings}")
         
         if self.settings:
             try:
@@ -60,8 +56,7 @@ class SerialReader:
                 with open(config_path, "r") as file:
                     device_file_name = file.readline().strip()
                     print(f"Meaurement Device config file found: {device_file_name}")
-                    device_file =  file.readline()
-                    print(f"Measurement Device config file found: {device_file}")
+
                     csv_path = os.path.join(os.getcwd(), "settings", "serial ports", device_file_name)
                     if os.path.exists(csv_path):
                         print(f"Device config file found: {device_file_name}")
@@ -74,8 +69,7 @@ class SerialReader:
                 with open(rfid_path, "r") as file:
                     device_file_name = file.readline().strip()
                     print(f"RFID Device config file found: {device_file_name}")
-                    device_file =  file.readline()
-                    print(f"RFID Device config file found: {device_file}")
+                    
                     csv_path = os.path.join(os.getcwd(), "settings", "serial ports", device_file_name)
                     if os.path.exists(csv_path):
                         print(f"Device config file found: {device_file_name}")

--- a/shared/serial_listener.py
+++ b/shared/serial_listener.py
@@ -1,17 +1,24 @@
 # pylint: skip-file
+import os
 import serial
 import threading
 from queue import Queue
 from shared.serial_port_controller import SerialPortController
 
 class SerialReader:
-    def __init__(self, timeout=1):
+    def __init__(self, timeout=1, port=None):
         '''Initializes the serial reader, opens the connection, and starts the listening thread.'''
+        print(f"Initializing SerialReader with port: {port}")
         self.timeout = timeout
         self.data_queue = Queue()   # A queue to hold the incoming data from the serial port
         self.running = True         # Flag to control the thread
-        self.port_controller = SerialPortController("serial_port_preference.csv")
-        self.settings = self.port_controller.retrieve_setting("serial_port_preference.csv")
+        self.device_file = self.find_device_config(port)
+        if not self.device_file:
+            print(f"ERROR: No configuration file found for {port}.")
+            self.running = False
+            return
+        self.port_controller = SerialPortController(self.device_file)
+        self.settings = self.port_controller.retrieve_setting(self.device_file)
         
         if self.settings:
             try:
@@ -36,6 +43,53 @@ class SerialReader:
         else:
             print("Error: Serial settings could not be loaded.")
             self.ser = None
+        
+    def find_device_config(self, port):
+        '''Find the corresponding .csv file for the given port.'''
+        preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference", port)
+        
+        if not os.path.exists(preference_dir):
+            print(f"ERROR: Preference folder for {port} not found.")
+            return None
+
+        try:
+            # Read the preferred configuration file
+            config_path = os.path.join(preference_dir, "preferred_config.txt")
+            rfid_path = os.path.join(preference_dir, "rfid_config.txt")
+            if os.path.exists(config_path):
+                with open(config_path, "r") as file:
+                    device_file_name = file.readline().strip()
+                    print(f"Meaurement Device config file found: {device_file_name}")
+                    device_file =  file.readline()
+                    print(f"Measurement Device config file found: {device_file}")
+                    csv_path = os.path.join(os.getcwd(), "settings", "serial ports", device_file_name)
+                    if os.path.exists(csv_path):
+                        print(f"Device config file found: {device_file_name}")
+                        return csv_path
+                    else:
+                        print(f"ERROR: Device config file {device_file_name} not found.")
+                        return None
+                    
+            elif os.path.exists(rfid_path):
+                with open(rfid_path, "r") as file:
+                    device_file_name = file.readline().strip()
+                    print(f"RFID Device config file found: {device_file_name}")
+                    device_file =  file.readline()
+                    print(f"RFID Device config file found: {device_file}")
+                    csv_path = os.path.join(os.getcwd(), "settings", "serial ports", device_file_name)
+                    if os.path.exists(csv_path):
+                        print(f"Device config file found: {device_file_name}")
+                        return csv_path
+                    else:
+                        print(f"ERROR: Device config file {device_file_name} not found.")
+
+            else:
+                print(f"ERROR: preferred_config.txt missing for {port}.")
+                return None
+        except Exception as e:
+            print(f"Error reading device config: {e}")
+            return None
+
 
     def read_from_serial(self):
         '''Runs in a background thread to read from the serial port.'''

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -8,7 +8,6 @@ writing. In order to do so, you must have both port established before
 you write to a port, else reading from the reader port will return
 nothing even if you write to writer port already
 '''
-
 import os
 import serial
 import serial.tools.list_ports
@@ -196,31 +195,31 @@ class SerialPortController():
         else:
             print("Invalid setting type. Must be 'reader' or 'device'.")
             return
-        
+
         preference_path = os.path.join(preference_dir, setting_folder, setting_file)
         print(f"🔍 Looking for settings in: {preference_path}")
-        
+
         if not os.path.exists(preference_path):
             print(f"Preference file {preference_path} not found.")
             return
-        
+
         try:
             with open(preference_path, "r") as file:
                 settings_file_name = file.readline().strip()
                 settings_path = os.path.join(os.getcwd(), "settings", "serial ports", settings_file_name)
-                
+
                 if not os.path.exists(settings_path):
                     print(f"Settings file {settings_path} not found.")
                     return
-                
+
                 with open(settings_path, "r") as settings_file:
                     settings = settings_file.readline().strip().split(',')
                     print("Successfully retrieved settings:", settings)
-                    
+
                     if len(settings) < 7:
                         print("Error: settings must have at least 7 elements.")
                         return
-                    
+
                     self.baud_rate = int(settings[0])
                     self.byte_size = getattr(serial, f"{settings[3].upper()}BITS", serial.EIGHTBITS)
                     self.parity = getattr(serial, f"PARITY_{settings[1].upper()}", serial.PARITY_NONE)

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -1,4 +1,5 @@
 '''Serial Port Settings is the page that allows user to set up serial port settings.'''
+# pylint: skip-file
 import csv
 from pathlib import Path
 from os import listdir, getcwd

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -198,24 +198,10 @@ class SerialPortSetting(SettingPage):
         self.save_button = CTkButton(self.edit_region, text="Save", command=self.save, height=14)
         self.save_button.grid(row=11, column=2, padx=20, pady=5, sticky="ns")
 
-        self.test_button = CTkButton(self.edit_region, text="Test Read", command=self.test_read, height=14)
-        self.test_button.grid(row=12, column=2, padx=20, pady=5, sticky="ns")
-
-        self.data_text = CTkLabel(self.edit_region, height=25, width=50, text="Waiting for Data...")
-        self.data_text.grid(row=13, column=2, columnspan=3, padx=20, pady=3, sticky="ew")
-
         self.back_to_summary_button = CTkButton(self.edit_region, text="Back to Summary", command=self.go_to_summary_page, height=14)
-        self.back_to_summary_button.grid(row=12, column=1, padx=20, pady=5, sticky="ns")
+        self.back_to_summary_button.grid(row=11, column=1, padx=20, pady=5, sticky="ns")
 
         self.serial_port_controller = SerialPortController(self.preference)
-
-    def update_label(self, data):
-        # Update the label with data from the test_read method
-        print(data)
-        self.data_text.configure(text=data)
-        self.master.update_idletasks()
-
-        #pylint: enable=line-too-long
 
     def summary_page(self, tab: str):
         ''' page that displays the setting of current configuration'''
@@ -367,67 +353,3 @@ class SerialPortSetting(SettingPage):
         self.configuration_name_entry.insert(0, file_name.with_suffix(""))
         self.confirm_setting()
         pass
-
-    def test_read(self):
-        '''Reads data from the serial port using the current settings on screen'''
-        if self.serial_port_controller:
-            try:
-                self.serial_port_controller.retrieve_setting([self.baud_rate_var.get(), self.data_bits_var.get(),
-                                                              self.parity_var.get(), self.stop_bits_var.get(),
-                                                              self.flow_control_var.get()])
-                self.serial_port_controller.update_setting(self.serial_port.get())
-                data = self.serial_port_controller.read_data()
-                print("Data read from serial port:" + str(data))
-                self.update_label("Data read from serial port: " + str(data))
-                return ("Data read from serial port: " + str(data))
-
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                print("Error reading from serial port:", e)
-                return None
-        else:
-            print("Serial port controller not initialized")
-            return None
-        
-
-if __name__ == "__main__":
-    root = CTk()
-    app = SerialPortSetting()
-
-    # TEST 1: Print Available Serial Ports
-    if app.serial_port_controller:
-        print("Available Serial Ports:", app.serial_port_controller.get_available_ports())
-    else:
-        print("ERROR: SerialPortController is not initialized!")
-
-    # TEST 2: Set a preference for a port and retrieve it
-    test_port = "COM3"  # Replace with an actual port on your system
-    test_config = "test_config.csv"
-
-    print(f"\nSetting preference for {test_port} to {test_config}...")
-    app.set_preference(test_port, test_config)
-
-    # Verify that preference is saved
-    preference_path = os.path.join(os.getcwd(), "settings", "serial ports", "preference", test_port, "preferred_config.txt")
-    if os.path.exists(preference_path):
-        with open(preference_path, "r") as file:
-            saved_config = file.read().strip()
-            print(f"Retrieved Preference: {saved_config}")
-            assert saved_config == test_config, "ERROR: Preference was not saved correctly!"
-
-    # TEST 3: Save a new configuration
-    test_settings = ["9600", "None", "None", "Eight", "1", "Binary", test_port]
-    print("\nSaving configuration...")
-    app.save("test_config", test_settings)
-
-    # Verify that configuration is saved
-    settings_path = os.path.join(os.getcwd(), "settings", "serial ports", "test_config.csv")
-    if os.path.exists(settings_path):
-        with open(settings_path, "r") as file:
-            saved_settings = file.read().strip()
-            print(f"Saved Configuration: {saved_settings}")
-            assert saved_settings == ",".join(test_settings), "ERROR: Configuration was not saved correctly!"
-
-    print("\nAll tests passed successfully!")
-
-    root.mainloop()
-

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -1,3 +1,4 @@
+'''Serial Port Settings is the page that allows user to set up serial port settings.'''
 import csv
 from pathlib import Path
 from os import listdir, getcwd
@@ -94,7 +95,7 @@ class SerialPortSetting(SettingPage):
         self.setting_configuration_label = CTkLabel(self.configuration_region, text="Existing Configuration", width=8, height=12)
         self.import_file = CTkOptionMenu(self.configuration_region, values=self.available_configuration, variable=self.current_configuration_name, height=12, width = 274)
         if self.preference:
-                self.import_file.set(self.preference)
+            self.import_file.set(self.preference)
         self.edit_configuration_button = CTkButton(self.configuration_region, text="Edit", width=2, height=14, command=self.edit_configuration)
         
         self.set_preference_button = CTkButton(
@@ -231,7 +232,6 @@ class SerialPortSetting(SettingPage):
         self.baud_rate_label.grid(row=1, column=0, padx=20, pady=5, sticky="ew")
         self.current_baud_rate.grid(row=1, column=2, padx=20, pady=5, sticky="ew")
 
-
         self.parity_label = CTkLabel(self.summary_section, text="Parity")
         self.current_parity = CTkLabel(self.summary_section, text=self.parity_var.get())
         self.parity_label.grid(row=2, column=0, padx=20, pady=5, sticky="ew")
@@ -241,7 +241,6 @@ class SerialPortSetting(SettingPage):
         self.current_flow_control = CTkLabel(self.summary_section, text=self.flow_control_var.get())
         self.flow_control_label.grid(row=3, column=0, padx=20, pady=5, sticky="ew")
         self.current_flow_control.grid(row=3, column=2, padx=20, pady=5, sticky="ew")
-
 
         self.data_bits_label = CTkLabel(self.summary_section, text="Data Bits")
         self.current_data_bits = CTkLabel(self.summary_section, text=self.data_bits_var.get())
@@ -262,7 +261,6 @@ class SerialPortSetting(SettingPage):
         self.edit_button.grid(row=8, column=2, padx=20, pady=40, sticky="ns")
 
         #pylint: enable=line-too-long
-
 
     def save(self):
         '''Save the current settings as a new or existing configuration.'''

--- a/shared/tk_models.py
+++ b/shared/tk_models.py
@@ -13,7 +13,6 @@ def raise_frame(frame: CTkFrame): #pylint: disable= redefined-outer-name
     current_frame = frame
     current_frame.pack()
    
-
 def create_nav_button(parent: CTkFrame, name: str, button_image: PhotoImage, frame: CTkFrame, relx: float, rely: float): #pylint: disable= line-too-long,redefined-outer-name
     '''Makes a navigation button to the various sub-menus of the program.'''
 
@@ -21,7 +20,6 @@ def create_nav_button(parent: CTkFrame, name: str, button_image: PhotoImage, fra
                     compound=TOP, width=25, command=lambda: raise_frame(frame))
     button.place(relx=relx, rely=rely, anchor=CENTER)
     button.image = button_image
-
 
 class MouserPage(CTkFrame):
 
@@ -102,6 +100,7 @@ class ChangeableFrame(ABC, CTkFrame):
         pass # pylint: disable= unnecessary-pass
 
 class SettingPage(CTkToplevel):
+    '''Initializes the SettingPage.'''
     def __init__(self, title: str):
         super().__init__()
         # Selecting GUI theme - dark,
@@ -109,6 +108,7 @@ class SettingPage(CTkToplevel):
         set_appearance_mode("light")
         # Selecting color theme-blue, green, dark-blue
         set_default_color_theme("dark-blue")
+        self.title(title)
         self.geometry("700x600")
 
 class MenuButton(CTkButton):


### PR DESCRIPTION
Fixes #260 

**What was changed?**

The application can now handle more than one (two) serial devices at a time. Created a test screen that can detect and test both RFID devices.

**Why was it changed?**

In order for our clients to be able to scan mice into the system AND take in measurements, they must be able to use RFID readers and measurement devices at the same time. This is a very important feature to the integrity of the deployment of this program.

**How was it changed?**

Rather than having one preference folder that finds the desired device settings, I split it into "Device" and "RFID" folders and did a bunch of changes to how objects like the serial controller, handler, and listener are instantiated in order to effectively maneuver which device is which. I haven't been able to test the true functionality of this just yet, but based on tests that I set throughout the code, it should work flawlessly. 

I added a button to the device configuration screen that can set devices to their respective categories (i.e. caliper settings would go to measurement device, reader would go to RFID device.

On top of that, I added a button to the main screen that can take you to a device testing screen to make sure that these devices are properly configured and working. This screen is hopefully a nice feature that the lab techs can use in order to ensure correct configuration before testing.

**Screenshots that show the changes (if applicable):**
