### PR TITLE
first changes to improve group mapping

### DIFF
--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -179,11 +179,9 @@ class CageConfigurationUI(MouserPage):
         self.update_config_frame()
 
     def clear_selections(self):
-        for animal_id in self.selected_animals:
-            if animal_id in self.animal_buttons:
-                self.animal_buttons[animal_id].set_color('default_color')  # Replace 'default_color' with the actual color code or variable
+        ## Emptys the set of selected animals
+
         self.selected_animals.clear()
-        print("All selections have been cleared.")
 
     def raise_warning(self, option: int):
         '''Raises a warning page.'''

--- a/experiment_pages/experiment/group_config_ui.py
+++ b/experiment_pages/experiment/group_config_ui.py
@@ -33,9 +33,6 @@ class GroupConfigUI(MouserPage): # pylint: disable= undefined-variable
         self.create_item_frame(self.experiment.get_measurement_items())
 
         self.experiment = experiment
-        self.selected_animals = []
-        self.swap_button = CTkButton(self.main_frame, text="Swap", state="disabled", command=self.perform_swap)
-        self.swap_button.pack(side=BOTTOM, pady=10)
 
         for i in range(0,2):
             self.grid_columnconfigure(i, weight=1)
@@ -98,27 +95,6 @@ class GroupConfigUI(MouserPage): # pylint: disable= undefined-variable
                 widget.destroy()
             self.create_item_frame(self.experiment.get_measurement_items())
             self.experiment.set_measurement_items_changed_false()
-
-    def select_for_swap(self, animal_id):
-        if animal_id in self.selected_animals:
-            self.selected_animals.remove(animal_id)
-        else:
-            self.selected_animals.append(animal_id)
-            if len(self.selected_animals) == 2:
-                self.swap_button['state'] = 'normal'
-            elif len(self.selected_animals) < 2:
-                self.swap_button['state'] = 'disabled'
-
-    def perform_swap(self):
-        if len(self.selected_animals) == 2:
-            self.selected_animals.swap_animals(self.selected_animals[0], self.selected_animals[1]) 
-            self.update_ui_after_swap()
-            self.selected_animals = []  # Reset selection
-            self.swap_button['state'] = 'disabled'
-
-    def update_ui_after_swap(self):
-        # Code to refresh the UI elements showing animal group/cage assignments
-        pass
 
     def save_experiment(self):
         '''Saves the experiment file to a the database file.'''

--- a/experiment_pages/experiment/group_config_ui.py
+++ b/experiment_pages/experiment/group_config_ui.py
@@ -32,6 +32,11 @@ class GroupConfigUI(MouserPage): # pylint: disable= undefined-variable
         self.create_group_entries(int(self.experiment.get_num_groups()))
         self.create_item_frame(self.experiment.get_measurement_items())
 
+        self.experiment = experiment
+        self.selected_animals = []
+        self.swap_button = CTkButton(self.main_frame, text="Swap", state="disabled", command=self.perform_swap)
+        self.swap_button.pack(side=BOTTOM, pady=10)
+
         for i in range(0,2):
             self.grid_columnconfigure(i, weight=1)
             self.grid_rowconfigure(i, weight=1)
@@ -45,6 +50,7 @@ class GroupConfigUI(MouserPage): # pylint: disable= undefined-variable
         self.next_button = ChangePageButton(self, next_page, False)# pylint: disable= undefined-variable
         self.next_button.configure(command= lambda: [self.save_experiment(), self.next_button.navigate()])
         self.next_button.place(relx=0.85, rely=0.15)
+
 
 
     def create_group_entries(self, num):
@@ -92,6 +98,27 @@ class GroupConfigUI(MouserPage): # pylint: disable= undefined-variable
                 widget.destroy()
             self.create_item_frame(self.experiment.get_measurement_items())
             self.experiment.set_measurement_items_changed_false()
+
+    def select_for_swap(self, animal_id):
+        if animal_id in self.selected_animals:
+            self.selected_animals.remove(animal_id)
+        else:
+            self.selected_animals.append(animal_id)
+            if len(self.selected_animals) == 2:
+                self.swap_button['state'] = 'normal'
+            elif len(self.selected_animals) < 2:
+                self.swap_button['state'] = 'disabled'
+
+    def perform_swap(self):
+        if len(self.selected_animals) == 2:
+            self.selected_animals.swap_animals(self.selected_animals[0], self.selected_animals[1]) 
+            self.update_ui_after_swap()
+            self.selected_animals = []  # Reset selection
+            self.swap_button['state'] = 'disabled'
+
+    def update_ui_after_swap(self):
+        # Code to refresh the UI elements showing animal group/cage assignments
+        pass
 
     def save_experiment(self):
         '''Saves the experiment file to a the database file.'''


### PR DESCRIPTION
Fixes #248 

**What was changed?**

The file was updated to include functionality for selecting two animals and swapping their group or cage assignments. This is not yet fully functioning.

**Why was it changed?**

The change was made to provide a more interactive and efficient way for users to manage group configurations within experiments. This functionality allows users to directly control animal assignments within the UI, which can be particularly useful in complex experimental setups.

**How was it changed?**

Implementing involved adding selection mechanisms next to each animal's display and a Swap button to initiate the swap. The swap button is not yet functioning. 
