### PR TITLE
No rfid mapping solution

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -25,11 +25,22 @@ class DataCollectionUI(MouserPage):
 
         self.database = ExperimentDatabase(database_name)
         self.measurement_items = self.database.get_measurement_items()
+        
+        ## ENSURE ANIMALS ARE IN DATABASE BEFORE EXPERIMENT FOR EXPERIMENTS W/O RFID ##
+        if self.database.experiment_uses_rfid() != 1:
+            i = 1
+            max_num_animals = self.database.get_number_animals()
+            while i <= max_num_animals:
+                self.database.add_animal(i, i)
+                i = i + 1
+
+
         self.measurement_strings = []
         self.measurement_ids = []
         for item in self.measurement_items:
             self.measurement_strings.append(item[1])
             self.measurement_ids.append(str(item[1]).lower().replace(" ", "_"))
+
 
         self.data_database = DataCollectionDatabase(database_name, self.measurement_strings)
 

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -35,13 +35,11 @@ class DataCollectionUI(MouserPage):
                 i = i + 1
 
 
-
         self.measurement_strings = []
         self.measurement_ids = []
         for item in self.measurement_items:
             self.measurement_strings.append(item[1])
             self.measurement_ids.append(str(item[1]).lower().replace(" ", "_"))
-
 
         self.data_database = DataCollectionDatabase(database_name, self.measurement_strings)
 

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -27,12 +27,15 @@ class DataCollectionUI(MouserPage):
         self.measurement_items = self.database.get_measurement_items()
         
         ## ENSURE ANIMALS ARE IN DATABASE BEFORE EXPERIMENT FOR EXPERIMENTS W/O RFID ##
-        if self.database.experiment_uses_rfid() != 1:
+        if self.database.experiment_uses_rfid() != 1 and self.database.get_animals() == []:
+            print(self.database.get_animals())
             i = 1
             max_num_animals = self.database.get_number_animals()
             while i <= max_num_animals:
                 self.database.add_animal(i, i)
                 i = i + 1
+        print(self.database.get_animals())
+
 
 
         self.measurement_strings = []

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -28,13 +28,11 @@ class DataCollectionUI(MouserPage):
         
         ## ENSURE ANIMALS ARE IN DATABASE BEFORE EXPERIMENT FOR EXPERIMENTS W/O RFID ##
         if self.database.experiment_uses_rfid() != 1 and self.database.get_animals() == []:
-            print(self.database.get_animals())
             i = 1
             max_num_animals = self.database.get_number_animals()
             while i <= max_num_animals:
                 self.database.add_animal(i, i)
                 i = i + 1
-        print(self.database.get_animals())
 
 
 


### PR DESCRIPTION
Fixes #271 

**What was changed?**

Added an additional check when opening the experiment (and thus calling the data_collection screen) to create and map pseudo RFIDs to the database to allow data collection without needing RFIDs.

**Why was it changed?**

This was change to match client functional needs of not having RFIDs on experiments, but still have full Mouser Functionality.

**How was it changed?**

Inside the data_collection.py file, the experiment now checks if there are animals with RFIDs mapped inside of the database. In the case that there are, the changes are ignored, and the program runs exactly as before. If there are not, however, as will be the case with experiments not utilizing RFID chips, it now creates "fake" RFIDs that just match the animal number. So, if there are 10 animals, numbered 1-10, "RFIDs" get mapped 1-10 corresponding to each animal. This allows for full database functionality and proper data collection/exporting without needing any RFID device or chips. In the case that an experiment is utilizing RFID and attempts to access this code without having mapped all RFIDs, the user is prevented by the button being disabled until all RFIDs are mapped, so no fake ones are simulated. 
