### PR TITLE
Device settings should save in .exe

### DIFF
--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - DatabaseRework
+      - SaveSettings
 
 jobs:
   build:

--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -49,7 +49,7 @@ jobs:
             --hidden-import "babel.numbers" \
             --add-data "shared/images/*:shared/images" \
             --add-data "shared/sounds/*:shared/sounds" \
-            --add-data "settings:settings"
+            --add-data "settings:settings" \
             main.py
         shell: bash #run in bash to avoid syntax error
 

--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -49,7 +49,7 @@ jobs:
             --hidden-import "babel.numbers" \
             --add-data "shared/images/*:shared/images" \
             --add-data "shared/sounds/*:shared/sounds" \
-            --add-data "settings;settings"
+            --add-data "settings:settings"
             main.py
         shell: bash #run in bash to avoid syntax error
 

--- a/settings/serial ports/.csv
+++ b/settings/serial ports/.csv
@@ -1,1 +1,0 @@
-4800,Even,None,Seven,2,Text,COM1

--- a/settings/serial ports/Caliper.csv
+++ b/settings/serial ports/Caliper.csv
@@ -1,1 +1,0 @@
-4800,Even,None,Seven,2,Text,COM1

--- a/settings/serial ports/random.csv
+++ b/settings/serial ports/random.csv
@@ -1,1 +1,0 @@
-300,Even,None,Five,2,Text,COM1

--- a/settings/serial ports/rfid_reader.csv
+++ b/settings/serial ports/rfid_reader.csv
@@ -1,1 +1,0 @@
-9600,None,None,Eight,1,Text,COM1

--- a/settings/serial ports/rfid_reader2.csv
+++ b/settings/serial ports/rfid_reader2.csv
@@ -1,1 +1,0 @@
-9600,None,None,Eight,1,Text,COM1

--- a/settings/serial ports/serial_port_preference.csv
+++ b/settings/serial ports/serial_port_preference.csv
@@ -1,1 +1,0 @@
-Caliper.csv

--- a/settings/serial ports/test1.csv
+++ b/settings/serial ports/test1.csv
@@ -1,1 +1,0 @@
-300,Odd,Xon/Xoff,Six,1.5,Text,COM5

--- a/settings/serial ports/test2.csv
+++ b/settings/serial ports/test2.csv
@@ -1,1 +1,0 @@
-4800,Mark,Hardware,Eight,1.5,Text,COM5

--- a/settings/serial ports/test_config.csv
+++ b/settings/serial ports/test_config.csv
@@ -1,1 +1,0 @@
-9600,None,None,Eight,1,Binary,COM3

--- a/settings/serial ports/test_reader.csv
+++ b/settings/serial ports/test_reader.csv
@@ -1,1 +1,0 @@
-9600,None,None,Eight,1,Text,COM1

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -83,14 +83,21 @@ class SerialPortSetting(SettingPage):
         self.summary_page("Map RFID")
         self.summary_page("Data Collection")
 
-        self.available_configuration = [file for file in listdir(self.port_setting_configuration_path)
-                                        if isfile(join(self.port_setting_configuration_path, file))]
+        if os.path.exists(self.port_setting_configuration_path):
+            self.available_configuration = [
+                file for file in listdir(self.port_setting_configuration_path)
+                if isfile(join(self.port_setting_configuration_path, file))
+            ]
+        else:
+            print(f"⚠️ Warning: Config path not found: {self.port_setting_configuration_path}")
+            self.available_configuration = []
+
         
     def get_base_path(self):
-        """Returns the directory of the executable or script."""
-        if getattr(sys, 'frozen', False):  # This is True for PyInstaller .exe
+        """Return the root path where the .exe or main.py is located."""
+        if getattr(sys, 'frozen', False):
             return os.path.dirname(sys.executable)
-        return os.path.dirname(os.path.abspath(__file__))
+        return os.path.dirname(os.path.abspath(sys.argv[0]))
 
     def edit_page(self, tab: str):
         ''' page that allow user to edit/update serial port settings'''

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -84,14 +84,20 @@ class SerialPortSetting(SettingPage):
         self.summary_page("Map RFID")
         self.summary_page("Data Collection")
 
-        if os.path.exists(self.port_setting_configuration_path):
-            self.available_configuration = [
-                file for file in listdir(self.port_setting_configuration_path)
-                if isfile(join(self.port_setting_configuration_path, file))
-            ]
-        else:
-            print(f"⚠️ Warning: Config path not found: {self.port_setting_configuration_path}")
-            self.available_configuration = []
+        self.available_configuration = []
+        read_config_path = os.path.join(self.get_read_path(), "settings", "serial ports")
+        write_config_path = os.path.join(self.get_write_path(), "settings", "serial ports")
+
+        # Read from both
+        for path in [read_config_path, write_config_path]:
+            if os.path.exists(path):
+                for file in listdir(path):
+                    full_path = join(path, file)
+                    if isfile(full_path) and file not in self.available_configuration:
+                        self.available_configuration.append(file)
+            else:
+                print(f"⚠️ Warning: Config path not found: {path}")
+
 
         
     def get_base_path(self):

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -39,7 +39,7 @@ class SerialPortSetting(SettingPage):
             base_path = sys._MEIPASS
         else:
             # Running from source
-            base_path = os.getcwd()
+            base_path = os.path.dirname(sys.argv[0])
 
         self.port_setting_configuration_path = os.path.join(base_path, "settings", "serial ports")
 
@@ -55,9 +55,10 @@ class SerialPortSetting(SettingPage):
 
         if preference:
             if preference == "device":
-                self.preference_path = os.path.join(os.getcwd(), "settings", "serial ports", "preference", "device", "preferred_config.txt")
+                self.preference_path = os.path.join(os.path.dirname(sys.argv[0]), "settings", "serial ports", "preference", "device", "preferred_config.txt")
             elif preference == "reader":
-                self.preference_path = os.path.join(os.getcwd(), "settings", "serial ports", "preference", "reader", "rfid_config.txt")
+                self.preference_path = os.path.join(os.path.dirname(sys.argv[0]), "settings", "serial ports", "preference", "reader", "rfid_config.txt")
+
             else:
                 self.preference_path = None  # Fallback if no valid type
 
@@ -277,7 +278,7 @@ class SerialPortSetting(SettingPage):
         if hasattr(sys, '_MEIPASS'):
             base_path = os.path.dirname(sys.executable)  # Path where the .exe resides
         else:
-            base_path = os.getcwd()
+            base_path = os.path.dirname(sys.argv[0])
 
         settings_dir = os.path.join(base_path, "settings", "serial ports")
         os.makedirs(settings_dir, exist_ok=True)
@@ -319,7 +320,7 @@ class SerialPortSetting(SettingPage):
         if hasattr(sys, '_MEIPASS'):
             base_path = os.path.dirname(sys.executable)
         else:
-            base_path = os.getcwd()
+            base_path = os.path.dirname(sys.argv[0])
 
         preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "device")
         os.makedirs(preference_dir, exist_ok=True)
@@ -337,7 +338,7 @@ class SerialPortSetting(SettingPage):
         if hasattr(sys, '_MEIPASS'):
             base_path = os.path.dirname(sys.executable)
         else:
-            base_path = os.getcwd()
+            base_path = os.path.dirname(sys.argv[0])
 
         preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "reader")
         os.makedirs(preference_dir, exist_ok=True)
@@ -355,7 +356,7 @@ class SerialPortSetting(SettingPage):
         if hasattr(sys, '_MEIPASS'):
             base_path = os.path.dirname(sys.executable)
         else:
-            base_path = os.getcwd()
+            base_path = os.path.dirname(sys.argv[0])
 
         config_dir = os.path.join(base_path, "settings", "serial ports")
         

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -79,10 +79,8 @@ class SerialPortSetting(SettingPage):
         self.tab_view = CTkTabview(master=self)
         self.tab_view.grid(padx=20, pady=20, sticky = "ew")
 
-        self.tab_view.add("Map RFID")
-        self.tab_view.add("Data Collection")
-        self.summary_page("Map RFID")
-        self.summary_page("Data Collection")
+        self.tab_view.add("Serial Settings")
+        self.summary_page("Serial Settings")
 
         self.available_configuration = []
         read_config_path = os.path.join(self.get_read_path(), "settings", "serial ports")
@@ -321,21 +319,17 @@ class SerialPortSetting(SettingPage):
         '''Function for the edit button on summary page, brings user
         to the edit page'''
         self.refresh_tabs()
-        self.edit_page("Map RFID")
-        self.edit_page("Data Collection")
+        self.edit_page("Serial Settings")
 
     def go_to_summary_page(self):
         '''Refresh tabs and display the summary page'''
         self.refresh_tabs()
-        self.summary_page("Map RFID")
-        self.summary_page("Data Collection")
+        self.summary_page("Serial Settings")
     
     def refresh_tabs(self):
         '''refreshes the page when updates are made'''
-        self.tab_view.delete("Map RFID")
-        self.tab_view.delete("Data Collection")
-        self.tab_view.add("Map RFID")
-        self.tab_view.add("Data Collection")
+        self.tab_view.delete("Serial Settings")
+        self.tab_view.add("Serial Settings")
 
     def set_preference(self, port, file_name):
         '''Save a specific configuration for a given port in its own preference folder.'''

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -274,7 +274,15 @@ class SerialPortSetting(SettingPage):
             self.serial_port.get()
         ]
 
-        settings_path = os.path.join(os.getcwd(), "settings", "serial ports", f"{configuration_name}.csv")
+        if hasattr(sys, '_MEIPASS'):
+            base_path = os.path.dirname(sys.executable)  # Path where the .exe resides
+        else:
+            base_path = os.getcwd()
+
+        settings_dir = os.path.join(base_path, "settings", "serial ports")
+        os.makedirs(settings_dir, exist_ok=True)
+
+        settings_path = os.path.join(settings_dir, f"{configuration_name}.csv")
 
         try:
             with open(settings_path, "w", newline="", encoding="utf-8") as file:
@@ -308,7 +316,12 @@ class SerialPortSetting(SettingPage):
 
     def set_preference(self, port, file_name):
         '''Save a specific configuration for a given port in its own preference folder.'''
-        preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference", "device")
+        if hasattr(sys, '_MEIPASS'):
+            base_path = os.path.dirname(sys.executable)
+        else:
+            base_path = os.getcwd()
+
+        preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "device")
         os.makedirs(preference_dir, exist_ok=True)
         preference_path = os.path.join(preference_dir, "preferred_config.txt")
         
@@ -321,7 +334,12 @@ class SerialPortSetting(SettingPage):
 
     def set_rfid(self, port, file_name):
         '''Save a specific configuration for a given port in its own preference folder.'''
-        preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference", "reader")
+        if hasattr(sys, '_MEIPASS'):
+            base_path = os.path.dirname(sys.executable)
+        else:
+            base_path = os.getcwd()
+
+        preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "reader")
         os.makedirs(preference_dir, exist_ok=True)
         preference_path = os.path.join(preference_dir, "rfid_config.txt")
         
@@ -332,24 +350,33 @@ class SerialPortSetting(SettingPage):
         except Exception as e:
             print(f"Error saving RFID Reader for {port}: {e}")
 
-    def confirm_setting(self, f = None):
-        '''select a configuration and use it as current serial
-        port setting'''
-        if f:
-            file_name = os.path.join(self.port_setting_configuration_path, f)
+    def confirm_setting(self, f=None):
+        '''select a configuration and use it as current serial port setting'''
+        if hasattr(sys, '_MEIPASS'):
+            base_path = os.path.dirname(sys.executable)
         else:
-            file_name = os.path.join(self.port_setting_configuration_path, self.current_configuration_name.get())
-        file = open(file_name)
-        csv_reader = reader(file)
-        for line in csv_reader:
-            self.baud_rate_var.set(line[0])
-            self.parity_var.set(line[1])
-            self.flow_control_var.set(line[2])
-            self.data_bits_var.set(line[3])
-            self.stop_bits_var.set(line[4])
-            self.input_bype_var.set(line[5])
-            self.serial_port.set(line[6])
-        file.close()
+            base_path = os.getcwd()
+
+        config_dir = os.path.join(base_path, "settings", "serial ports")
+        
+        if f:
+            file_name = os.path.join(config_dir, f)
+        else:
+            file_name = os.path.join(config_dir, self.current_configuration_name.get())
+
+        try:
+            with open(file_name) as file:
+                csv_reader = reader(file)
+                for line in csv_reader:
+                    self.baud_rate_var.set(line[0])
+                    self.parity_var.set(line[1])
+                    self.flow_control_var.set(line[2])
+                    self.data_bits_var.set(line[3])
+                    self.stop_bits_var.set(line[4])
+                    self.input_bype_var.set(line[5])
+                    self.serial_port.set(line[6])
+        except Exception as e:
+            print(f"Error loading configuration: {e}")
 
 
     def edit_configuration(self):

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -33,13 +33,7 @@ class SerialPortSetting(SettingPage):
         else:
             self.serial_port_controller = SerialPortController(self.preference)
 
-
-        if hasattr(sys, '_MEIPASS'):
-            # Running as a bundled executable
-            base_path = sys._MEIPASS
-        else:
-            # Running from source
-            base_path = os.path.dirname(sys.argv[0])
+        base_path = self.get_base_path()
 
         self.port_setting_configuration_path = os.path.join(base_path, "settings", "serial ports")
 
@@ -55,13 +49,11 @@ class SerialPortSetting(SettingPage):
 
         if preference:
             if preference == "device":
-                self.preference_path = os.path.join(os.path.dirname(sys.argv[0]), "settings", "serial ports", "preference", "device", "preferred_config.txt")
+                self.preference_path = os.path.join(base_path, "settings", "serial ports", "preference", "device", "preferred_config.txt")
             elif preference == "reader":
-                self.preference_path = os.path.join(os.path.dirname(sys.argv[0]), "settings", "serial ports", "preference", "reader", "rfid_config.txt")
-
+                self.preference_path = os.path.join(base_path, "settings", "serial ports", "preference", "reader", "rfid_config.txt")
             else:
                 self.preference_path = None  # Fallback if no valid type
-
             
             if os.path.exists(self.preference_path):
                 try:
@@ -93,6 +85,12 @@ class SerialPortSetting(SettingPage):
 
         self.available_configuration = [file for file in listdir(self.port_setting_configuration_path)
                                         if isfile(join(self.port_setting_configuration_path, file))]
+        
+    def get_base_path(self):
+        """Returns the directory of the executable or script."""
+        if getattr(sys, 'frozen', False):  # This is True for PyInstaller .exe
+            return os.path.dirname(sys.executable)
+        return os.path.dirname(os.path.abspath(__file__))
 
     def edit_page(self, tab: str):
         ''' page that allow user to edit/update serial port settings'''
@@ -275,10 +273,7 @@ class SerialPortSetting(SettingPage):
             self.serial_port.get()
         ]
 
-        if hasattr(sys, '_MEIPASS'):
-            base_path = os.path.dirname(sys.executable)  # Path where the .exe resides
-        else:
-            base_path = os.path.dirname(sys.argv[0])
+        base_path = self.get_base_path()
 
         settings_dir = os.path.join(base_path, "settings", "serial ports")
         os.makedirs(settings_dir, exist_ok=True)
@@ -317,10 +312,7 @@ class SerialPortSetting(SettingPage):
 
     def set_preference(self, port, file_name):
         '''Save a specific configuration for a given port in its own preference folder.'''
-        if hasattr(sys, '_MEIPASS'):
-            base_path = os.path.dirname(sys.executable)
-        else:
-            base_path = os.path.dirname(sys.argv[0])
+        base_path = self.get_base_path()
 
         preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "device")
         os.makedirs(preference_dir, exist_ok=True)
@@ -335,10 +327,7 @@ class SerialPortSetting(SettingPage):
 
     def set_rfid(self, port, file_name):
         '''Save a specific configuration for a given port in its own preference folder.'''
-        if hasattr(sys, '_MEIPASS'):
-            base_path = os.path.dirname(sys.executable)
-        else:
-            base_path = os.path.dirname(sys.argv[0])
+        base_path = self.get_base_path()
 
         preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "reader")
         os.makedirs(preference_dir, exist_ok=True)
@@ -353,10 +342,7 @@ class SerialPortSetting(SettingPage):
 
     def confirm_setting(self, f=None):
         '''select a configuration and use it as current serial port setting'''
-        if hasattr(sys, '_MEIPASS'):
-            base_path = os.path.dirname(sys.executable)
-        else:
-            base_path = os.path.dirname(sys.argv[0])
+        base_path = self.get_base_path()
 
         config_dir = os.path.join(base_path, "settings", "serial ports")
         
@@ -378,7 +364,6 @@ class SerialPortSetting(SettingPage):
                     self.serial_port.set(line[6])
         except Exception as e:
             print(f"Error loading configuration: {e}")
-
 
     def edit_configuration(self):
         '''allow user to edit existing configuration by overwriting


### PR DESCRIPTION
Fixes *issue not yet defined, will be*

**What was changed?**

Device settings could not save in the executable version of Mouser, they now can!

**Why was it changed?**

Although we have Dr. Toth's current devices hardcoded to Mouser, this addition will be important if our clients desire a hardware change/ new kind of measurement.

**How was it changed?**

os.getcwd() only works with command line versions of programs, replacing that with conditionals that check whether the program is running from the command line vs executable clears up confusion for the system to find paths.