### PR TITLE
Max animal divisibility check removed

### DIFF
--- a/experiment_pages/create_experiment/new_experiment_ui.py
+++ b/experiment_pages/create_experiment/new_experiment_ui.py
@@ -185,10 +185,7 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
         message.resizable(True, True)
 
         # Add the appropriate warning message based on the option
-        if option == 1:
-            label = CTkLabel(message, text='Number of animals must be divisible by number groups.')
-            label.grid(row=0, column=0, padx=10, pady=10)
-        elif option == 2:
+        if option == 2:
             label1 = CTkLabel(message, text='Number of animals, groups, or maximum')
             label2 = CTkLabel(message, text='animals per cage must be greater than 0.')
             label1.grid(row=0, column=0, padx=10)
@@ -228,13 +225,9 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
             self.raise_warning(4)
         elif self.animal_num.get() == '' or self.group_num.get() == '' or self.animal_num.get() == '':
             self.raise_warning(2)
-        elif int(self.animal_num.get()) % int(self.group_num.get()) != 0:
-            self.raise_warning(1)
         elif int(self.animal_num.get()) == 0 or int(self.group_num.get()) == 0 or int(self.animal_num.get()) == 0:
             self.raise_warning(2)
-        elif int(self.group_num.get()) * int(self.num_per_cage.get()) > int(self.animal_num.get()):
-            self.raise_warning(1)
-        elif int(self.animal_num.get()) % int(self.group_num.get()) == 0 and int(self.animal_num.get()) != 0:
+        else:
             self.save_input()
 
     def save_input(self):
@@ -250,6 +243,5 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
         self.input.set_num_animals(self.animal_num.get())
         self.input.set_num_groups(self.group_num.get())
         self.input.set_max_animals(self.num_per_cage.get())
-        self.input.set_animals_per_group(int(self.animal_num.get()) / int(self.group_num.get()))
 
         self.next_page.update_page()


### PR DESCRIPTION
**What was changed?**

Removed warning option 1 and all checks for max animal divisibility. Tested a newly created experiment with 7 animals and 2 cages and all other feat. including data collection, map rfid, and data export are functional.

**Why was it changed?**
Max animals were forced to be exactly equal to max animals per cage * number of cages. This does not fit with client lab specifications as sometimes the experiments are run such that not all cages are filled e.g. 2 cages with 7 hamsters).


The screenshot below was ran on the branch from https://github.com/oss-slu/Mouser/pull/286 as group/cage config is not updated on main. 

**Screenshots that show the changes**
![image](https://github.com/user-attachments/assets/4ba50e07-899a-4a52-9670-70e66d397228)
