### PR TITLE
Fixed Investigator Text Box Issue

### DIFF
--- a/experiment_pages/create_experiment/new_experiment_ui.py
+++ b/experiment_pages/create_experiment/new_experiment_ui.py
@@ -236,7 +236,13 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
         if self.password.get():
             self.input.set_password(self.password.get())
         self.input.set_unique_id()
-        self.input.set_investigators(self.added_invest)
+        
+        # Combine added investigators with any remaining text in the text box
+        all_investigators = self.added_invest.copy()
+        if self.investigators.get().strip():
+            all_investigators.append(self.investigators.get().strip())
+        self.input.set_investigators(all_investigators)
+        
         self.input.set_species(self.species.get())
         self.input.set_measurement_item(self.measure_items.get())
         self.input.set_uses_rfid(self.rfid.get())


### PR DESCRIPTION
Fixes Investigator Adding Issue

**What was changed?**

The New Experiment page now takes the investigator in the text box without having to hit the + button.

**Why was it changed?**

This was changed to have the program better match client needs and requests. 

**How was it changed?**

When saving, the program now checks if there is anything within the investigator text box. If there is, it adds it to the list of investigators. 

