### PR TITLE
Investigator fix

### DIFF
--- a/experiment_pages/create_experiment/new_experiment_ui.py
+++ b/experiment_pages/create_experiment/new_experiment_ui.py
@@ -77,7 +77,7 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
         self.group_num.grid(row=8, column=1, sticky=W, padx=pad_x, pady=pad_y)
         self.num_per_cage.grid(row=9, column=1, sticky=W, padx=pad_x, pady=pad_y)
 
-        self.rfid = BooleanVar()
+        self.rfid = BooleanVar(value=True)
 
         CTkRadioButton(self.rfid_frame, text='Yes', variable=self.rfid, value=1).grid(row=0, column=0,
                     padx=pad_x, pady=pad_y)

--- a/experiment_pages/create_experiment/new_experiment_ui.py
+++ b/experiment_pages/create_experiment/new_experiment_ui.py
@@ -62,7 +62,7 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
         self.investigators = CTkEntry(self.main_frame, width=140)
         self.species = CTkEntry(self.main_frame, width=140)
 
-        self.measure_items = CTkEntry(self.main_frame, width=140)
+        self.measure_items = CTkEntry(self.main_frame, width=140, textvariable=StringVar(value="Weight"))
 
         self.animal_num = CTkEntry(self.main_frame, width=110)
         self.group_num = CTkEntry(self.main_frame, width=110)

--- a/experiment_pages/create_experiment/new_experiment_ui.py
+++ b/experiment_pages/create_experiment/new_experiment_ui.py
@@ -107,6 +107,7 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
         self.animal_num.bind("<KeyRelease>", lambda event: self.enable_next_button())
         self.group_num.bind("<KeyRelease>", lambda event: self.enable_next_button())
         self.num_per_cage.bind("<KeyRelease>", lambda event: self.enable_next_button())
+        self.investigators.bind("<Return>", lambda event: [self.add_investigator(), self.investigators.delete(0, END)])
 
     def enable_next_button(self):
         if self.exper_name.get() and self.species.get() \

--- a/experiment_pages/experiment/group_config_ui.py
+++ b/experiment_pages/experiment/group_config_ui.py
@@ -69,7 +69,7 @@ class GroupConfigUI(MouserPage): # pylint: disable= undefined-variable
         type_label.grid(row=0, column=0, columnspan=3, pady=8)
 
         # Since item is now a string, we directly use it
-        self.type = BooleanVar()  # Variable to hold the input method
+        self.type = BooleanVar(value=True)  # Variable to hold the input method
         self.button_vars.append(self.type)
 
         CTkLabel(self.item_frame, text=item).grid(row=1, column=0, padx=10, pady=10, sticky=W)


### PR DESCRIPTION
The Enter key can now be pressed to input a researcher name while creating a new experiment.

Commonly used default values added for measurement items, RFID, and data collection settings while creating new experiment.