### PR TITLE
AutoSave Functionality Implementation, Map RFID Page Fixes, Move Group Button on Group Config

### DIFF
--- a/databases/database_controller.py
+++ b/databases/database_controller.py
@@ -62,7 +62,7 @@ class DatabaseController():
         self.db._c.execute("SELECT cage_max FROM experiment")
         result = self.db._c.fetchone()
         return int(result[0]) if result else 0
-    
+
     def get_animals_in_group(self, group_name):
         '''Returns list of animals in a given group/cage'''
         return self.db.get_animals_in_cage(group_name)
@@ -71,12 +71,10 @@ class DatabaseController():
         '''Returns a list of all measurement items in the database.'''
         return self.measurement_items
 
-    def get_cages_in_group(self, group):
-        '''Returns a list of all cage ids in the specified group.'''
-        if group in self.cages_in_group:
-            return self.cages_in_group[group]
-        return []
-    
+    def get_cage_number(self, cage_name):
+        '''Returns the internal number of a cage from its name'''
+        return self.db.get_cage_number(cage_name)
+
     def autosort(self):
         '''Calls the Database Autosort Function'''
         self.db.autosort()
@@ -139,8 +137,11 @@ class DatabaseController():
         self.db.update_experiment(updated_animals)
         self.reset_attributes()
 
+    def commit(self):
+        self.db._conn.commit()
+
     def close(self):
         '''Closes the database file.'''
         self.db.close()
-    
+
 

--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -667,3 +667,10 @@ class ExperimentDatabase:
             print(f"Error during autosort: {e}")
             self._conn.rollback()
             return False
+
+    def get_cage_number(self, cage_name):
+        self._c.execute('''
+                        SELECT group_id FROM groups
+                        WHERE name = ?''', (cage_name,))
+        result = self._c.fetchone()
+        return result[0] if result else None

--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -110,11 +110,9 @@ class ExperimentDatabase:
             # Update group count
             self._c.execute('''UPDATE groups
                             SET num_animals = num_animals - 1
-                            WHERE group_id = ?''', (group_id))
+                            WHERE group_id = ?''', (group_id,))
 
-            # Deactivate animal instead of deleting
-            self._c.execute("UPDATE animals SET active = 0 WHERE animal_id = ?", (animal_id,))
-            self._conn.commit()
+            self._c.execute("DELETE FROM animals WHERE animal_id = ?", (animal_id,))
         else:
             raise LookupError(f"No animal found with ID {animal_id}")
 
@@ -191,7 +189,7 @@ class ExperimentDatabase:
         self._c.execute("SELECT num_animals FROM experiment")
         result = self._c.fetchone()
         if result:
-            print(result[0])
+            print("Total number of animals in DB: ",result[0])
             return result[0]
         return 0
 
@@ -414,12 +412,21 @@ class ExperimentDatabase:
         return result[0] if result else 0  # Default to manual (0)
 
     def get_all_animal_ids(self):
-        '''Returns a list of all animal IDs that have RFIDs mapped to them.'''
+        '''Returns a list of all active animal IDs that have RFIDs mapped to them.'''
         self._c.execute('''
             SELECT animal_id
             FROM animals
             WHERE rfid IS NOT NULL
             AND active = 1
+        ''')
+        return [animal[0] for animal in self._c.fetchall()]
+    
+    def get_all_animals(self):
+        '''Returns a list of ALL animals ACTIVE OR NOT with RFIDs'''
+        self._c.execute('''
+            SELECT animal_id
+            FROM animals
+            WHERE rfid IS NOT NULL
         ''')
         return [animal[0] for animal in self._c.fetchall()]
 

--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -189,7 +189,7 @@ class ExperimentDatabase:
         self._c.execute("SELECT num_animals FROM experiment")
         result = self._c.fetchone()
         if result:
-            print("Total number of animals in DB: ",result[0])
+            print("Total number of animals in Experiment: ",result[0])
             return result[0]
         return 0
 

--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -183,19 +183,19 @@ class ExperimentDatabase:
             if self._conn is not None:
                 # Commit any pending transactions
                 self._conn.commit()
-                
+
                 # Close the cursor if it exists
                 if self._c is not None:
                     self._c.close()
                     self._c = None
-                
+
                 # Close the connection
                 self._conn.close()
                 self._conn = None
-                
+
                 # Clear the singleton instance
                 ExperimentDatabase._instance = None
-                
+
                 return True
         except Exception as e:
             print(f"Error during database cleanup: {e}")
@@ -236,7 +236,7 @@ class ExperimentDatabase:
         result = self._c.fetchone()
         return result[0] if result else None
 
-    def get_animal_id(self, rfid):
+    def get_animal_id(self, rfid: str):
         '''Returns the animal ID for a given RFID.'''
         self._c.execute('SELECT animal_id FROM animals WHERE rfid = ?', (rfid,))
         result = self._c.fetchone()
@@ -451,7 +451,7 @@ class ExperimentDatabase:
             AND active = 1
         ''')
         return [animal[0] for animal in self._c.fetchall()]
-    
+
     def get_all_animals(self):
         '''Returns a list of ALL animals ACTIVE OR NOT with RFIDs'''
         self._c.execute('''

--- a/experiment_pages/create_experiment/summary_ui.py
+++ b/experiment_pages/create_experiment/summary_ui.py
@@ -27,29 +27,36 @@ class CreateExperimentButton(CTkButton):
             measurement_type = 1 if self.experiment.get_measurement_type() else 0
             self.experiment.set_measurement_type(measurement_type)  # Set it before saving
             self.experiment.save_to_database(directory)
+            
             if self.experiment.get_password():
                 password = self.experiment.get_password()
-                file = directory + '/' + self.experiment.get_name() + '.pmouser'
+                # Use os.path.join for file path
+                file = os.path.join(directory, f"{self.experiment.get_name()}.pmouser")
+                
                 manager = PasswordManager(password)
                 decrypted_data = manager.decrypt_file(file)
+                
                 temp_folder_name = "Mouser"
                 temp_folder_path = os.path.join(tempfile.gettempdir(), temp_folder_name)
                 os.makedirs(temp_folder_path, exist_ok=True)
-                temp_file_name = self.experiment.get_name() + '.pmouser'
+                
+                temp_file_name = f"{self.experiment.get_name()}.pmouser"
                 temp_file_path = os.path.join(temp_folder_path, temp_file_name)
+                
                 if os.path.exists(temp_file_path):
                     os.remove(temp_file_path)
 
                 with open(temp_file_path, "wb") as temp_file:
                     temp_file.write(decrypted_data)
                     temp_file.seek(0)
-                    root= self.winfo_toplevel() #pylint: disable= redefined-outer-name
+                    root = self.winfo_toplevel() #pylint: disable= redefined-outer-name
                     page = ExperimentMenuUI(root, temp_file.name)
 
             else:
-                file = directory + '/' + self.experiment.get_name() + '.mouser'
-                root= self.winfo_toplevel()
-                page = ExperimentMenuUI(root, file)
+                # Use os.path.join for file path
+                file = os.path.join(directory, f"{self.experiment.get_name()}.mouser")
+                root = self.winfo_toplevel()
+                page = ExperimentMenuUI(root, file, None, file)
                 raise_frame(page) #pylint: disable=undefined-variable
 
 class SummaryUI(MouserPage):# pylint: disable=undefined-variable

--- a/experiment_pages/create_experiment/summary_ui.py
+++ b/experiment_pages/create_experiment/summary_ui.py
@@ -27,22 +27,22 @@ class CreateExperimentButton(CTkButton):
             measurement_type = 1 if self.experiment.get_measurement_type() else 0
             self.experiment.set_measurement_type(measurement_type)  # Set it before saving
             self.experiment.save_to_database(directory)
-            
+
             if self.experiment.get_password():
                 password = self.experiment.get_password()
                 # Use os.path.join for file path
                 file = os.path.join(directory, f"{self.experiment.get_name()}.pmouser")
-                
+
                 manager = PasswordManager(password)
                 decrypted_data = manager.decrypt_file(file)
-                
+
                 temp_folder_name = "Mouser"
                 temp_folder_path = os.path.join(tempfile.gettempdir(), temp_folder_name)
                 os.makedirs(temp_folder_path, exist_ok=True)
-                
+
                 temp_file_name = f"{self.experiment.get_name()}.pmouser"
                 temp_file_path = os.path.join(temp_folder_path, temp_file_name)
-                
+
                 if os.path.exists(temp_file_path):
                     os.remove(temp_file_path)
 

--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -170,7 +170,6 @@ class CageConfigurationUI(MouserPage):
         confirm = CTkMessagebox(
             title= "Confirm AutoSort",
             message= "Are you sure you want to AutoSort? \nThis will remove measurements used to sort from the database.",
-            icon="question",
             option_1="No",
             option_2="Yes"
         )

--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -4,14 +4,17 @@ from shared.tk_models import *
 from shared.scrollable_frame import ScrolledFrame
 from databases.database_controller import DatabaseController
 from shared.audio import AudioManager
+from shared.file_utils import save_temp_to_file
 
 class CageConfigurationUI(MouserPage):
     '''The Frame that allows user to configure the cages.'''
-    def __init__(self, database, parent: CTk, prev_page: CTkFrame = None):
+    def __init__(self, database, parent: CTk, prev_page: CTkFrame = None, file_path = ''):
         super().__init__(parent, "Cage Configuration", prev_page)
 
         self.prev_page = prev_page
         self.db = DatabaseController(database)
+
+        self.file_path = file_path
 
         scroll_canvas = ScrolledFrame(self)
         scroll_canvas.place(relx=0.05, rely=0.20, relheight=0.75, relwidth=0.88)
@@ -25,6 +28,8 @@ class CageConfigurationUI(MouserPage):
                             command=self.perform_swap)
         auto_button = CTkButton(input_frame, text='AutoSort', width=15,
                                 command=self.autosort)
+        move_button = CTkButton(input_frame, text='Move Cages', width=15,
+                                command=self.move_animal)
 
         self.id_input = CTkEntry(input_frame, width=110)
         self.cage_input = CTkEntry(input_frame, width=110)
@@ -40,6 +45,7 @@ class CageConfigurationUI(MouserPage):
         auto_button.grid(row=0, column=0, padx=self.pad_x, pady=self.pad_y)
         random_button.grid(row=0, column=1, padx=self.pad_x, pady=self.pad_y)
         swap_button.grid(row=0, column=2, padx=self.pad_x, pady=self.pad_y)
+        move_button.grid(row=0, column=3, padx=self.pad_x, pady=self.pad_y)
 
         for i in range(0, 3):
             input_frame.grid_columnconfigure(i, weight=1)
@@ -48,7 +54,9 @@ class CageConfigurationUI(MouserPage):
         input_frame.pack(side=TOP, fill=X, anchor='center')
         self.config_frame.pack(side=TOP, fill=BOTH, anchor='center')
         self.animal_buttons = {}
+        self.cage_buttons = {}
         self.selected_animals = set()
+        self.selected_cage = None
 
         self.update_config_frame()
 
@@ -66,9 +74,18 @@ class CageConfigurationUI(MouserPage):
         for cage_name in cages:
             cage_frame = CTkFrame(self.config_frame, border_width=3, border_color="#00e7ff", bg_color='#0097A7')
 
-            # Cage header
-            label = CTkLabel(cage_frame, text=f'Cage: {cage_name}', bg_color='#0097A7', font=label_style)
-            label.pack(side=TOP, padx=self.pad_x, pady=self.pad_y, anchor='center')
+            # Cage header - now a button instead of a label
+            cage_button = CTkButton(
+                cage_frame,
+                text=f'Cage: {cage_name}',
+                command=lambda c=cage_name: self.select_cage(c),
+                fg_color='#0097A7',
+                hover_color="#00b8d4",
+                text_color="white",
+                font=label_style
+            )
+            cage_button.pack(side=TOP, padx=self.pad_x, pady=self.pad_y, anchor='center')
+            self.cage_buttons[cage_name] = cage_button
 
             # Create header frame for labels
             header_frame = CTkFrame(cage_frame)
@@ -95,6 +112,29 @@ class CageConfigurationUI(MouserPage):
 
             cage_frame.pack(side=LEFT, expand=TRUE, fill=BOTH, anchor='center')
 
+    def select_cage(self, cage_name):
+        '''Handles cage selection by updating the cage input field and visual feedback.'''
+        button = self.cage_buttons.get(cage_name)
+        if button:
+            if self.selected_cage == cage_name:
+                # Deselect current cage
+                self.selected_cage = None
+                button.configure(fg_color="#0097A7")  # Reset to default blue
+                self.cage_input.delete(0, END)
+                self.cage_input.insert(0, 'cage id')
+                print(f"Deselected cage: {cage_name}")
+            else:
+                # Deselect previous cage if any
+                if self.selected_cage and self.selected_cage in self.cage_buttons:
+                    self.cage_buttons[self.selected_cage].configure(fg_color="#0097A7")
+
+                # Select new cage
+                self.selected_cage = cage_name
+                button.configure(fg_color="#D5E8D4")  # Selected state green
+                self.cage_input.delete(0, END)
+                self.cage_input.insert(0, cage_name)
+                print(f"Selected cage: {cage_name}")
+
     def toggle_animal_selection(self, animal_id):
         '''Toggles the selection state of an animal.'''
         button = self.animal_buttons.get(animal_id)
@@ -104,10 +144,9 @@ class CageConfigurationUI(MouserPage):
                 button.configure(fg_color="#0097A7")  # Reset to default blue
                 print(f"Deselected animal: {animal_id}")
             else:
-                if len(self.selected_animals) < 2:
-                    self.selected_animals.add(animal_id)
-                    button.configure(fg_color="#D5E8D4")  # Selected state green
-                    print(f"Selected animal: {animal_id}")
+                self.selected_animals.add(animal_id)
+                button.configure(fg_color="#D5E8D4")  # Selected state green
+                print(f"Selected animal: {animal_id}")
             print(f"Currently selected animals: {self.selected_animals}")
         else:
             print(f"Error: No button found for Animal ID: {animal_id}")
@@ -123,11 +162,13 @@ class CageConfigurationUI(MouserPage):
         '''Autosorts the animals into cages.'''
         self.db.randomize_cages()
         self.update_config_frame()
+        self.save()
 
     def autosort(self):
         '''Calls database's autosort function.'''
         self.db.autosort()
         self.update_config_frame()
+        self.save()
 
     def perform_swap(self):
         '''Swaps two selected animals between cages.'''
@@ -151,6 +192,56 @@ class CageConfigurationUI(MouserPage):
 
         self.selected_animals.clear()
         self.update_config_frame()
+        self.save()
+
+    def move_animal(self):
+        '''Moves selected animals to a specified cage.'''
+        # Check if any animals are selected
+        if not self.selected_animals:
+            self.raise_warning("Please select at least one animal to move.")
+            return
+
+        # Check if exactly one cage is selected
+        if not self.selected_cage:
+            self.raise_warning("Please select a target cage.")
+            return
+
+        target_cage = self.selected_cage  # The display name
+        target_group = self.db.get_cage_number(target_cage)  # The internal number
+
+        # Check if moving would exceed cage maximum
+        target_cage_count = len(self.db.get_animals_in_group(target_cage))
+        if target_cage_count + len(self.selected_animals) > self.db.get_cage_max():
+            self.raise_warning(f"Moving these animals would exceed the maximum cage capacity of {self.db.get_cage_max()}.")
+            return
+
+        # Track if any animals were actually moved
+        animals_moved = False
+
+        # Move each selected animal
+        for animal_id in list(self.selected_animals):  # Convert to list to avoid modifying set during iteration
+            # Get current cage of the animal
+            current_cage = self.db.get_animal_current_cage(animal_id)
+
+            # Skip if animal is already in target cage
+            if current_cage == target_group:
+                continue
+
+            # Perform the move using the database controller with internal group number
+            self.db.update_animal_cage(animal_id, target_group)
+            animals_moved = True
+
+        if not animals_moved:
+            self.raise_warning("No animals were moved. They might already be in the target cage.")
+            return
+
+        # Clear selections and update the UI
+        self.selected_animals.clear()
+        self.selected_cage = None
+        if target_cage in self.cage_buttons:  # Use display name for button lookup
+            self.cage_buttons[target_cage].configure(fg_color="#0097A7")  # Reset cage button color
+        self.update_config_frame()
+        self.save()
 
     def raise_warning(self, message):
         '''Raises a warning page with the given message.'''
@@ -176,6 +267,25 @@ class CageConfigurationUI(MouserPage):
             raise_frame(self.prev_page)
         else:
             self.raise_warning(f'Number of animals in a cage must not exceed {self.db.get_cage_max()}')
+
+    def save(self):
+        '''Saves current database state to permanent file'''
+        try:
+            current_file = self.db.db.db_file
+
+            # Ensure all changes are committed
+            self.db.commit()
+            print("Changes committed")
+
+            # Save back to original file location
+            print(f"Saving {current_file} to {self.file_path}")
+            save_temp_to_file(current_file, self.file_path)
+            print("Save successful!")
+
+        except Exception as e:
+            print(f"Error during save: {e}")
+            import traceback
+            print(f"Full traceback: {traceback.format_exc()}")
 
     def check_num_in_cage_allowed(self):
         '''Checks if the number of animals in a cage is allowed.'''

--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -1,6 +1,7 @@
 '''Contains cage configuration page and behaviour.'''
 from customtkinter import *
 from shared.tk_models import *
+from CTkMessagebox import CTkMessagebox
 from shared.scrollable_frame import ScrolledFrame
 from databases.database_controller import DatabaseController
 from shared.audio import AudioManager
@@ -165,10 +166,18 @@ class CageConfigurationUI(MouserPage):
         self.save()
 
     def autosort(self):
-        '''Calls database's autosort function.'''
-        self.db.autosort()
-        self.update_config_frame()
-        self.save()
+        '''Calls database's autosort function after user confirmation.'''
+        confirm = CTkMessagebox(
+            title= "Confirm AutoSort",
+            message= "Are you sure you want to AutoSort? \nThis will remove measurements used to sort from the database.",
+            icon="question",
+            option_1="No",
+            option_2="Yes"
+        )
+        if confirm.get() == "Yes":
+            self.db.autosort()
+            self.update_config_frame()
+            self.save()
 
     def perform_swap(self):
         '''Swaps two selected animals between cages.'''

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -274,7 +274,7 @@ class DataCollectionUI(MouserPage):
             self.database.change_data_entry(str(date.today()), animal_id_to_change, new_value)
             print("Database entry updated")
 
-            # Update display table 
+            # Update display table
             try:
                 for child in self.table.get_children():
                     if animal_id_to_change == self.table.item(child)["values"][0]:
@@ -289,11 +289,11 @@ class DataCollectionUI(MouserPage):
                     # Ensure all changes are committed
                     self.database._conn.commit()
                     print("Changes committed")
-                    
+
                     print(f"Attempting to save {self.database.db_file} to {self.current_file_path}")
                     save_temp_to_file(self.database.db_file, self.current_file_path)
                     print("Autosave Success!")
-                    
+
                 except Exception as save_error:
                     print(f"Autosave failed: {save_error}")
                     print(f"Error type: {type(save_error)}")
@@ -352,7 +352,7 @@ class ChangeMeasurementsDialog():
             values = self.data_collection.table.item(child)["values"]
             self.animal_ids.append(values[0])
         self.current_index = 0
-        
+
         self.root = root = CTkToplevel(self.parent)
 
         title_text = "Modify Measurements for: " + str(animal_id)

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -392,7 +392,10 @@ class ChangeMeasurementsDialog():
                     if self.data_collection.database.get_measurement_type() == 1:
                         print("Inside the if statement")
 
-                        current_index = self.animal_ids.index(animal_id)
+                        if animal_id = len(self.animal_ids) + 1:
+                            current_index = len(self.animal_ids) + 1
+                        else:
+                            current_index = self.animal_ids.index(animal_id)
 
                         while current_index < len(self.animal_ids) and self.thread_running:
                             if len(data_handler.received_data) >= 2:  # Customize condition

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -410,9 +410,15 @@ class ChangeMeasurementsDialog():
                                         data_thread.join()
                                         break
                                     else:
-                                        next_animal_id = self.animal_ids[current_index + 1]
-                                        self.data_collection.select_animal_by_id(next_animal_id)
-                                        break
+                                        if current_index + 1 < len(self.animal_ids): # If there are more animals
+                                            next_animal_id = self.animal_ids[current_index + 1]
+                                            self.data_collection.select_animal_by_id(next_animal_id)
+                                            break
+                                        else: # End of animal list, pass value to exit while loop
+                                            next_animal_id = len(self.animal_ids) + 1
+                                            self.data_collection.select_animal_by_id(next_animal_id)
+                                            break
+
                                 else:
                                     # Resume RFID listening if in RFID mode
                                     if not self.data_collection.rfid_stop_event.is_set():

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -392,7 +392,7 @@ class ChangeMeasurementsDialog():
                     if self.data_collection.database.get_measurement_type() == 1:
                         print("Inside the if statement")
 
-                        if animal_id = len(self.animal_ids) + 1:
+                        if animal_id == len(self.animal_ids) + 1:
                             current_index = len(self.animal_ids) + 1
                         else:
                             current_index = self.animal_ids.index(animal_id)

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -8,19 +8,22 @@ from databases.experiment_database import ExperimentDatabase
 from shared.audio import AudioManager
 from shared.scrollable_frame import ScrolledFrame
 from shared.serial_handler import SerialDataHandler
+from shared.file_utils import save_temp_to_file
 import threading
 
 #pylint: disable= undefined-variable
 class DataCollectionUI(MouserPage):
     '''Page Frame for Data Collection.'''
 
-    def __init__(self, parent: CTk, prev_page: CTkFrame = None, database_name = ""):
+    def __init__(self, parent: CTk, prev_page: CTkFrame = None, database_name = "", file_path = ""):
 
         super().__init__(parent, "Data Collection", prev_page)
 
         self.rfid_reader = None
         self.rfid_stop_event = threading.Event()  # Event to stop RFID listener
         self.rfid_thread = None # Store running thread
+
+        self.current_file_path = file_path
 
         self.database = ExperimentDatabase(database_name)
 
@@ -263,17 +266,43 @@ class DataCollectionUI(MouserPage):
 
     def change_selected_value(self, animal_id_to_change, list_of_values):
         '''Updates the table and database with the new value.'''
-        new_value = float(list_of_values[0])
-        print(animal_id_to_change)
-        print(new_value)
-        self.database.change_data_entry(str(date.today()), animal_id_to_change, new_value)
+        try:
+            new_value = float(list_of_values[0])
+            print(f"Saving data point for animal {animal_id_to_change}: {new_value}")
 
-        for child in self.table.get_children():
-            if animal_id_to_change == self.table.item(child)["values"][0]:
-                self.table.item(child, values=(animal_id_to_change, new_value))
+            # Write change to database
+            self.database.change_data_entry(str(date.today()), animal_id_to_change, new_value)
+            print("Database entry updated")
 
+            # Update display table 
+            try:
+                for child in self.table.get_children():
+                    if animal_id_to_change == self.table.item(child)["values"][0]:
+                        self.table.item(child, values=(animal_id_to_change, new_value))
+                print("Table display updated")
+            except Exception as table_error:
+                print(f"Error updating table display: {table_error}")
 
-
+            # Autosave: Commit and save the database file
+            if hasattr(self.database, 'db_file') and self.database.db_file != ":memory:":
+                try:
+                    # Ensure all changes are committed
+                    self.database._conn.commit()
+                    print("Changes committed")
+                    
+                    print(f"Attempting to save {self.database.db_file} to {self.current_file_path}")
+                    save_temp_to_file(self.database.db_file, self.current_file_path)
+                    print("Autosave Success!")
+                    
+                except Exception as save_error:
+                    print(f"Autosave failed: {save_error}")
+                    print(f"Error type: {type(save_error)}")
+                    import traceback
+                    print(f"Full traceback: {traceback.format_exc()}")
+        except Exception as e:
+            print(f"Top level error: {e}")
+            import traceback
+            print(f"Full traceback: {traceback.format_exc()}")
 
     def get_values_for_date(self):
         '''Gets the data for the current date as a string in YYYY-MM-DD.'''
@@ -313,18 +342,17 @@ class ChangeMeasurementsDialog():
         self.measurement_items = str(measurement_items)  # Ensure measurement_items is a single string
         self.database = data_collection.database  # Reference to the updated database
         self.uses_rfid = self.database.experiment_uses_rfid() == 1
-
-        if not self.uses_rfid:
-            # Get list of all animal IDs from the table
-            self.animal_ids = []
-            for child in self.data_collection.table.get_children():
-                values = self.data_collection.table.item(child)["values"]
-                self.animal_ids.append(values[0])  # First column contains animal IDs
-            self.current_index = 0  # Track position in animal_ids list
-            self.thread_running = False  # Add a flag to control the thread's life cycle
+        self.thread_running = False
 
     def open(self, animal_id):
         '''Opens the change measurement dialog window and handles automated submission.'''
+         # Initialize animal_ids unconditionally - we need this list for both RFID and non-RFID cases
+        self.animal_ids = []
+        for child in self.data_collection.table.get_children():
+            values = self.data_collection.table.item(child)["values"]
+            self.animal_ids.append(values[0])
+        self.current_index = 0
+        
         self.root = root = CTkToplevel(self.parent)
 
         title_text = "Modify Measurements for: " + str(animal_id)

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -399,46 +399,39 @@ class ChangeMeasurementsDialog():
 
                         while current_index < len(self.animal_ids) and self.thread_running:
                             if len(data_handler.received_data) >= 2:  # Customize condition
-                                # Check if the widget still exists before trying to update it
-                                try:
-                                    if entry.winfo_exists():  # Check if entry widget still exists
-                                        received_data = data_handler.get_stored_data()
-                                        entry.insert(1, received_data)
-                                        data_handler.stop()
+                                received_data = data_handler.get_stored_data()
+                                entry.insert(1, received_data)
+                                data_handler.stop()
 
-                                        if not self.uses_rfid:
-                                            print("Current table index:", current_index)
-                                            self.finish(animal_id)  # Pass animal_id to finish method
-                                            if current_index >= len(self.animal_ids):
-                                                print("closing!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-                                                data_thread.join()
-                                                break
-                                            else:
-                                                # Check if we have more animals in the list
-                                                if current_index + 1 < len(self.animal_ids):
-                                                    next_animal_id = self.animal_ids[current_index + 1]
-                                                    self.data_collection.select_animal_by_id(next_animal_id)
-                                                else:
-                                                    # If we're at the end, use length + 1 as the next ID
-                                                    next_animal_id = len(self.animal_ids) + 1
-                                                    self.data_collection.select_animal_by_id(next_animal_id)
-                                                break
-                                        else:
-                                            if not self.data_collection.rfid_stop_event.is_set():
-                                                self.data_collection.rfid_listen()
-                                                self.finish(animal_id)
-                                                break
-                                    else:
-                                        # Widget no longer exists, stop the thread
-                                        self.thread_running = False
+                                if not self.uses_rfid:
+                                    # Find current index in animal_ids list
+                                    print("Current table index:", current_index)
+                                    # If not at the end of the list, move to next animal
+                                    self.finish(animal_id)  # Pass animal_id to finish method
+                                    if current_index >= len(self.animal_ids):
+                                        print("closing!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+                                        data_thread.join()
                                         break
-                                except Exception as e:
-                                    print(f"Widget error: {e}")
-                                    self.thread_running = False
-                                    break
+                                    else:
+                                        if current_index + 1 < len(self.animal_ids): # If there are more animals
+                                            next_animal_id = self.animal_ids[current_index + 1]
+                                            self.data_collection.select_animal_by_id(next_animal_id)
+                                            break
+                                        else: # End of animal list, pass value to exit while loop
+                                            next_animal_id = len(self.animal_ids) + 1
+                                            self.data_collection.select_animal_by_id(next_animal_id)
+                                            break
+
+                                else:
+                                    # Resume RFID listening if in RFID mode
+                                    if not self.data_collection.rfid_stop_event.is_set():
+                                        self.data_collection.rfid_listen()
+                                        self.finish(animal_id)  # Pass animal_id to finish method
+                                        break
 
                                 time.sleep(.25)
 
+                        # Stop the thread once max measurements are reached
                         self.thread_running = False
                         print("Thread finished")
 

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -13,7 +13,7 @@ from experiment_pages.experiment.review_ui import ReviewUI
 
 class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
     '''Experiment Menu Page Frame'''
-    def __init__(self, parent: CTk, name: str, prev_page: ChangeableFrame = None, controller: SerialPortController = None): #pylint: disable= undefined-variable
+    def __init__(self, parent: CTk, name: str, prev_page: ChangeableFrame = None, full_path: str = "", controller: SerialPortController = None): #pylint: disable= undefined-variable
 
         #review imported here to prevent a reference loop from occuring
 
@@ -22,6 +22,8 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         experiment_name = os.path.basename(name)
         experiment_name = os.path.splitext(experiment_name)[0]
         self.experiment = ExperimentDatabase(name)
+
+        self.file_path = full_path
 
         super().__init__(parent, experiment_name, prev_page)
 
@@ -40,7 +42,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
         main_frame.grid_columnconfigure(0, weight = 1)
         main_frame.grid_columnconfigure(1, weight = 1)
 
-        self.data_page = DataCollectionUI(parent, self, name)
+        self.data_page = DataCollectionUI(parent, self, name, self.file_path)
         self.analysis_page = DataAnalysisUI(parent, self, os.path.abspath(name))
         self.cage_page = CageConfigurationUI(name, parent, self)
         self.summary_page = ReviewUI(parent, self, name)

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -44,7 +44,7 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
 
         self.data_page = DataCollectionUI(parent, self, name, self.file_path)
         self.analysis_page = DataAnalysisUI(parent, self, os.path.abspath(name))
-        self.cage_page = CageConfigurationUI(name, parent, self)
+        self.cage_page = CageConfigurationUI(name, parent, self, self.file_path)
         self.summary_page = ReviewUI(parent, self, name)
         if controller is None:
             self.rfid_page = MapRFIDPage(name, parent, self, self.file_path)

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -488,14 +488,12 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         if len(self.db.get_all_animals_rfid()) != self.db.get_total_number_animals():
             self.raise_warning('Not all animals have been mapped to RFIDs')
         else:
-            # Save the current state before closing the database
-
-
+            # Save the current state before cleaning up
             current_file = self.db.db_file
-
-            self.db._conn.commit()
-            self.db.close()
-
+            
+            # Commit any pending changes and close the singleton instance
+            self.db.close()  # This will now handle the singleton cleanup
+            
             self.stop_listening()
 
             # Local import to avoid circular dependency

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -455,7 +455,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 
                 # Create new ExperimentMenuUI instance with the same file
-                new_page = ExperimentMenuUI(self.parent, self.file_path, self.menu_page)
+                new_page = ExperimentMenuUI(self.parent, self.file_path, self.menu_page, self.file_path)
                 new_page.raise_frame()
 
             except Exception as e:

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -169,7 +169,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                         continue  # 🚫 Avoid calling add_value()
 
                     # If it's a new RFID, process it
-                    self.after(0, lambda: self.add_value(clean_rfid, self.db))
+                    self.after(0, lambda: self.add_value(clean_rfid))
                     self.animal_rfid_list.append(clean_rfid)
                     play_sound_async("shared/sounds/rfid_success.wav")
 
@@ -267,29 +267,12 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.change_entry_text()
 
 
-    def add_value(self, rfid, db=None):
+    def add_value(self, rfid):
         """Adds RFID to the table, stops listening, checks the count, then restarts or stops."""
 
         if rfid is None or rfid == "":
             print("🚫 Skipping None/Empty RFID value... No entry will be added.")
             return  # ✅ Prevents adding a blank entry
-
-        if db is None:
-            db = self.db
-
-        # Clean up RFID value if it's coming from a reader
-        if isinstance(rfid, str):
-            # Remove any non-numeric characters
-            rfid = ''.join(filter(str.isdigit, rfid))
-            if not rfid:  # If no digits were found
-                print(f"Invalid RFID format received: {rfid}")
-                return
-
-        try:
-            rfid = int(rfid)  # Convert to integer
-        except (ValueError, TypeError) as e:
-            print(f"Error converting RFID to integer: {e}")
-            return
 
         item_id = self.animal_id
 
@@ -315,8 +298,8 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.change_entry_text()
 
         # Add to database with determined group
-        db.add_animal(animal_id=item_id, rfid=rfid, group_id=current_group)
-        db._conn.commit()
+        self.db.add_animal(item_id, rfid, current_group, '')
+        self.db._conn.commit()
 
         AudioManager.play("shared/sounds/rfid_success.wav")
 

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -349,9 +349,11 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
         for item in selected_items:
             item_id = int(self.table.item(item, 'values')[0])
+            rfid_value = self.table.item(item, 'values')[1]
             self.table.selection_remove(item)
             self.table.delete(item)
             self.db.remove_animal(item_id)
+            self.animal_rfid_list.remove(rfid_value)
             print("Total number of animal rows in the table:", len(self.table.get_children()))
 
         self.save()

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -106,6 +106,10 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                                       state="normal")  # Initialize as enabled
         self.sacrifice_button.place(relx=0.80, rely=0.80, anchor=CENTER)
 
+        self.stop_scanning_button = CTkButton(self, text="Stop Listening", compound=TOP,
+                                  width=250, height=75, font=("Georgia", 65), command=self.stop_listening)
+        self.stop_scanning_button.place(relx=0.10, rely=0.80, anchor=CENTER)
+
         self.item_selected(None)
 
         animals_setup = self.db.get_all_animal_ids()
@@ -166,6 +170,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                     elif clean_rfid in self.animal_rfid_list:
                         print(f"⚠️ RFID {clean_rfid} is already in use! Skipping...")
                         play_sound_async("shared/sounds/error.wav")
+                        self.raise_warning("This RFID tag has already been mapped to an animal")
                         continue  # 🚫 Avoid calling add_value()
 
                     else:

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -381,6 +381,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
         for item in selected_items:
             item_id = int(self.table.item(item, 'values')[0])
+            self.table.selection_remove(item)
             self.table.delete(item)
             self.db.remove_animal(item_id)
             print("Total number of animal rows in the table:", len(self.table.get_children()))
@@ -402,8 +403,8 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         '''returns the next animal in our experiment.'''
         total_animals = self.db.get_total_number_animals()
         # Get list of existing ACTIVE animal IDs from the database
-        existing_animal_ids = set(self.db.get_all_animals())  # Changed from get_all_animal_ids()
-        
+        existing_animal_ids = set(self.db.get_all_animals())  
+
         # Find the first gap in the sequence
         for animal_id in range(1, total_animals + 1):
             if animal_id not in existing_animal_ids:
@@ -521,6 +522,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         # First mark the selected animals as inactive
         for item in selected_items:
             animal_id = int(self.table.item(item, 'values')[0])
+            self.table.selection_remove(item)
             self.table.delete(item)
             self.db.set_animal_active_status(animal_id, 0)  # Mark as inactive
             self.animals = [(index, rfid) for (index, rfid) in self.animals if index != animal_id]
@@ -529,13 +531,15 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             self.change_entry_text()
 
             # Then decrease the maximum number of animals
-            current_max = self.db.get_number_animals()
+            current_max = self.db.get_total_number_animals()
+            current_max = current_max - 1
             if current_max <= 0:
                 self.raise_warning("Cannot reduce animal count below 0")
                 return
             else:
                 # Decrease the maximum number of animals by 1
                 self.db.set_number_animals(current_max)
+
 
 class ChangeRFIDDialog():
     '''Change RFID user interface.'''

--- a/main.py
+++ b/main.py
@@ -48,7 +48,16 @@ def open_file():
     '''
     file_path = askopenfilename(filetypes=[("Database files",".mouser .pmouser")])
     print(file_path)
+    global TEMP_FILE_PATH
+
     if file_path:
+
+        # Close any existing db connections to respect singleton
+        if TEMP_FILE_PATH and os.path.exists(TEMP_FILE_PATH):
+            from databases.experiment_database import ExperimentDatabase
+            if ExperimentDatabase._instance is not None:
+                ExperimentDatabase._instance.close()
+
         global CURRENT_FILE_PATH
         CURRENT_FILE_PATH = file_path
 
@@ -89,7 +98,6 @@ def open_file():
             password_button.pack()
         else:
             temp_file = file_utils.create_temp_copy(file_path)
-            global TEMP_FILE_PATH
             TEMP_FILE_PATH = temp_file
             page = ExperimentMenuUI(root, temp_file, experiments_frame, file_path)
             page.raise_frame()

--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def open_file():
             temp_file = file_utils.create_temp_copy(file_path)
             global TEMP_FILE_PATH
             TEMP_FILE_PATH = temp_file
-            page = ExperimentMenuUI(root, temp_file, experiments_frame)
+            page = ExperimentMenuUI(root, temp_file, experiments_frame, file_path)
             page.raise_frame()
 #pylint:enable = global-statement
 


### PR DESCRIPTION
Fixes #292 , #257 , and #232 

**What was changed?**

The AutoSave function has been implemented into all relevant screens, including the Group Config screen, the Map RFID screen, and the Data Collection Screen. In addition, the bugs related to Map RFID, including when removing selected animals, sacrificing animals, and how the list and database were set up, have been resolved. Now, when an animal is removed/sacrificed, the correct animal ID is assigned to the next scanned/simulated one as needed. In addition, a stop listening button has been added to prevent issues with threading should it be needed. Lastly, a Move Group button has been added to the Group Config screen. This allows for either a one animal to be moved from one group to another, or several to be moved from the same or different groups into another one. It has error checking and still ensures the user cannot move more animals into a group than is allowed for the experiment. In addition, a confirmation screen has been added to the autosort feature to prevent accidental presses deleting data. 

**Why was it changed?**

AutoSave was added per the clients specifications, as it was requested to be saving automatically after every data point, RFID, or group config chang was recorded. This way, at the moment anything is changed in the database, a permanent file with that change is updated, all without user intervention. 

**How was it changed?**

The largest AutoSave backend change is the database now acting as a singleton. Rather than allowing the program to connect to the database from each screen, the program now checks if a connection already exists. It it does, the screen requesting the connection uses the same one as the others. If not, it builds one connection. The other important changes come from the three affected screens class creation arguments. For each one, a new argument has been added. It is a string containing the location of the permanent file that needs to be saved to, and each file uses the save_temp_to_file function from the shared utilities to write to the permanent file. 

For the Map RFID fixes, the largest change is the get_next_animal function. This is what fixes the numbering issue, and with the save changes mentioned above the two fix the issues that were found. To my testing, it is currently an unbreakable screen (but please let me know if you get unexpected behavior!). Map RFID also now has a button in the bottom corner to stop listening to the rfid reader the same way the one on data collection works. 

Group Config changes are the changing of the group names from text boxes to buttons, building the select function for said buttons (only allowing one to be pressed at a time), and the move animal function, which internally and externally moves any selected animals into the selected group. Group config now raises a message box which the user must either click on or close before continuing the usage of the program (with nothing happening if it is closed rather than an option selected).
