### PR TITLE
first changes in adding error dialogue

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -4,6 +4,7 @@ from tkinter.ttk import Treeview, Style
 import time
 from customtkinter import *
 from shared.tk_models import *
+from CTkMessagebox import CTkMessagebox
 from databases.experiment_database import ExperimentDatabase
 from shared.audio import AudioManager
 from shared.scrollable_frame import ScrolledFrame
@@ -156,6 +157,14 @@ class DataCollectionUI(MouserPage):
 
         self.changer = ChangeMeasurementsDialog(parent, self, self.measurement_strings)
 
+    def raise_warning(self, warning_message='An error occurred'):
+        '''Raises a popup warning message.'''
+        CTkMessagebox(
+            title="Warning",
+            message=warning_message,
+            icon="warning"
+        )
+        AudioManager.play("shared/sounds/error.wav")
 
     def item_selected(self, _):
         '''On item selection.
@@ -246,8 +255,8 @@ class DataCollectionUI(MouserPage):
                                 AudioManager.play("shared/sounds/rfid_success.wav")
                                 self.after(600, lambda: self.select_animal_by_id(animal_id))
                             else:
-                                AudioManager.play("shared/sounds/error.wav")
-                                print("❌ No animal found for scanned RFID.")
+                                self.raise_warning("No animal found for scanned RFID.")
+
 
 
                     time.sleep(0.1)  # Shorter sleep time for more responsive stopping
@@ -377,6 +386,7 @@ class DataCollectionUI(MouserPage):
                     import traceback
                     print(f"Full traceback: {traceback.format_exc()}")
         except Exception as e:
+            self.raise_warning("Failed to save data for animal.")
             print(f"Top level error: {e}")
             import traceback
             print(f"Full traceback: {traceback.format_exc()}")

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -438,6 +438,13 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                         command= lambda: [message.destroy()])
         ok_button.grid(row=2, column=0, padx=10, pady=10)
 
+        FlashOverlay(
+            parent=self,
+            message=warning_message,
+            duration=2000,
+            bg_color="red",
+            text_color="black"
+        )
         AudioManager.play("shared/sounds/error.wav")
 
         message.mainloop()

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -214,13 +214,15 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         if self.rfid_thread and self.rfid_thread.is_alive():
             self.rfid_thread.join(timeout=1)  # Ensure the thread fully stops
 
-        if self.rfid_reader:  # Make sure the serial reader is released
+        if self.rfid_reader:
             try:
                 print("🔌 Closing serial connection...")
                 self.rfid_reader.stop()
-                self.rfid_reader = None  # Reset the reader instance
+                self.rfid_reader = None
             except Exception as e:
+                self.raise_warning("Failed to close the serial port properly.")
                 print(f"⚠️ Error closing serial port: {e}")
+
 
         time.sleep(0.5)  # Allow OS to release the port
 
@@ -493,9 +495,9 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 new_page.raise_frame()
 
             except Exception as e:
+                self.raise_warning("An error occurred while saving or cleaning up.")
                 print(f"Error during save and cleanup: {e}")
-                import traceback
-                print(f"Full traceback: {traceback.format_exc()}")
+
 
 
     def raise_frame(self):
@@ -519,7 +521,8 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             print("Save successful!")
 
         except Exception as e:
-            print(f"Error during save: {e}")
+            self.raise_warning("An error occurred while saving or cleaning up.")
+            print(f"Error during save and cleanup: {e}")
             import traceback
             print(f"Full traceback: {traceback.format_exc()}")
 


### PR DESCRIPTION
Fixes #307 

**What was changed?**

 A raise_warning function was added to DataCollectionUI, and error situations during RFID scanning and data saving were updated to call this warning popup instead of only printing errors.

**Why was it changed?**

 It was changed to provide clear, immediate feedback to the user during errors, improving usability and making error handling consistent with other parts of the application like Map RFID.

**How was it changed?**

 The change introduced a CTkMessagebox popup alongside playing an error sound whenever an RFID scan failed or saving data failed, ensuring users get a visible and audible alert.
