### PR TITLE
Serial settings and sounds work correctly in .exe

### DIFF
--- a/.github/workflows/create-executable.yml
+++ b/.github/workflows/create-executable.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - DatabaseRework
-      - SaveSettings
+      - test-exe
 
 jobs:
   build:
@@ -26,14 +25,14 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install --upgrade setuptools wheel
       - run: pip install -r requirements.txt pyinstaller importlib-metadata sacremoses tokenizers
-          
+
       # Only run this on macOS as brew isn't available on Windows
       # - run: brew install mysql pkg-config portaudio
         # if: ${{ matrix.os == 'macos-latest' }}
-      
+
       # Uninstalling typing for compatibility with Python 3.11
       - run: pip uninstall -y typing
-      
+
       # Modify PyInstaller command to include additional data
       - run: |
           pyinstaller --noconfirm --noconsole --onedir -c \

--- a/experiment_pages/create_experiment/new_experiment_ui.py
+++ b/experiment_pages/create_experiment/new_experiment_ui.py
@@ -6,6 +6,7 @@ from shared.scrollable_frame import ScrolledFrame
 from experiment_pages.experiment.group_config_ui import GroupConfigUI
 from shared.experiment import Experiment
 from shared.audio import AudioManager
+from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
 
 
 class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
@@ -201,7 +202,7 @@ class NewExperimentUI(MouserPage):# pylint: disable= undefined-variable
             label4.grid(row=0, column=0, padx=10, pady=10)
 
         # Play the error sound
-        AudioManager.play("sounds/error.wav")
+        AudioManager.play(ERROR_SOUND)
 
         # Bind key and mouse events to dismiss the warning
         message.bind("<KeyPress>", dismiss_warning)  # Captures any key press

--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -5,6 +5,7 @@ from CTkMessagebox import CTkMessagebox
 from shared.scrollable_frame import ScrolledFrame
 from databases.database_controller import DatabaseController
 from shared.audio import AudioManager
+from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
 from shared.file_utils import save_temp_to_file
 
 class CageConfigurationUI(MouserPage):
@@ -164,7 +165,7 @@ class CageConfigurationUI(MouserPage):
         self.db.randomize_cages()
         self.update_config_frame()
         self.save()
-        AudioManager.play("shared/sounds/rfid_success.wav")
+        AudioManager.play(SUCCESS_SOUND)
 
     def autosort(self):
         '''Calls database's autosort function after user confirmation.'''
@@ -178,7 +179,7 @@ class CageConfigurationUI(MouserPage):
             self.db.autosort()
             self.update_config_frame()
             self.save()
-            AudioManager.play("shared/sounds/rfid_success.wav")
+            AudioManager.play(SUCCESS_SOUND)
 
     def perform_swap(self):
         '''Swaps two selected animals between cages.'''
@@ -203,7 +204,7 @@ class CageConfigurationUI(MouserPage):
         self.selected_animals.clear()
         self.update_config_frame()
         self.save()
-        AudioManager.play("shared/sounds/rfid_success.wav")
+        AudioManager.play(SUCCESS_SOUND)
 
     def move_animal(self):
         '''Moves selected animals to a specified cage.'''
@@ -253,7 +254,7 @@ class CageConfigurationUI(MouserPage):
             self.cage_buttons[target_cage].configure(fg_color="#0097A7")  # Reset cage button color
         self.update_config_frame()
         self.save()
-        AudioManager.play("shared/sounds/rfid_success.wav")
+        AudioManager.play(SUCCESS_SOUND)
 
     def raise_warning(self, message):
         '''Raises a warning page with the given message.'''
@@ -269,7 +270,7 @@ class CageConfigurationUI(MouserPage):
                             command=lambda: message_window.destroy())
         ok_button.grid(row=2, column=0, padx=10, pady=10)
 
-        AudioManager.play("shared/sounds/error.wav")
+        AudioManager.play(ERROR_SOUND)
         message_window.mainloop()
 
     def save_to_database(self):

--- a/experiment_pages/experiment/data_analysis_ui.py
+++ b/experiment_pages/experiment/data_analysis_ui.py
@@ -7,6 +7,7 @@ from tkinter import filedialog
 from shared.tk_models import *
 from databases.experiment_database import ExperimentDatabase
 from shared.audio import AudioManager
+from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
 
 class DataAnalysisUI(MouserPage):
     '''Data Exporting UI.'''
@@ -69,7 +70,7 @@ class DataAnalysisUI(MouserPage):
             db = ExperimentDatabase(self.db_file)
             db.export_to_single_formatted_csv(save_dir)
             print("Data exported successfully to CSV files.")
-            AudioManager.play("shared/sounds/rfid_success.wav")
+            AudioManager.play(SUCCESS_SOUND)
             # Replace the notification with our new success message
             self.show_success_message()
         except Exception as e:

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -6,6 +6,7 @@ from customtkinter import *
 from shared.tk_models import *
 from CTkMessagebox import CTkMessagebox
 from databases.experiment_database import ExperimentDatabase
+from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
 from shared.audio import AudioManager
 from shared.scrollable_frame import ScrolledFrame
 from shared.serial_handler import SerialDataHandler
@@ -164,7 +165,7 @@ class DataCollectionUI(MouserPage):
             message=warning_message,
             icon="warning"
         )
-        AudioManager.play("shared/sounds/error.wav")
+        AudioManager.play(ERROR_SOUND)
 
     def item_selected(self, _):
         '''On item selection.
@@ -206,7 +207,7 @@ class DataCollectionUI(MouserPage):
                     bg_color="#00FF00", #Bright Green
                     text_color="black"
                 )
-                AudioManager.play("shared/sounds/rfid_success.wav")
+                AudioManager.play(SUCCESS_SOUND)
 
         print("📡 Starting RFID listener...")
         print("All RFIDs:", self.database.get_all_animals_rfid())
@@ -252,7 +253,7 @@ class DataCollectionUI(MouserPage):
                                     bg_color="#00FF00", # Bright Green
                                     text_color="black"
                                 )
-                                AudioManager.play("shared/sounds/rfid_success.wav")
+                                AudioManager.play(SUCCESS_SOUND)
                                 self.after(600, lambda: self.select_animal_by_id(animal_id))
                             else:
                                 self.raise_warning("No animal found for scanned RFID.")
@@ -564,7 +565,7 @@ class ChangeMeasurementsDialog():
             if self.data_collection.winfo_exists():
                 # Update the database with the new values
                 self.data_collection.change_selected_value(current_animal_id, values)
-                AudioManager.play("shared/sounds/rfid_success.wav")
+                AudioManager.play(SUCCESS_SOUND)
 
     def get_all_values(self):
         '''Returns the values of all entries in self.textboxes as an array.'''

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -10,6 +10,7 @@ from customtkinter import *
 from CTkMessagebox import CTkMessagebox
 from playsound import playsound
 from serial import serialutil
+from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
 from shared.tk_models import *
 from shared.serial_port_controller import SerialPortController
 from shared.serial_handler import SerialDataHandler
@@ -180,7 +181,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
                     elif clean_rfid in self.animal_rfid_list:
                         print(f"⚠️ RFID {clean_rfid} is already in use! Skipping...")
-                        AudioManager.play("shared/sounds/error.wav")
+                        AudioManager.play(ERROR_SOUND)
                         self.raise_warning("This RFID tag has already been mapped to an animal")
                         continue  # 🚫 Avoid calling add_value()
 
@@ -188,7 +189,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                         # If it's a new RFID, process it
                         self.after(0, lambda: self.add_value(clean_rfid))
                         self.animal_rfid_list.append(clean_rfid)
-                        AudioManager.play("shared/sounds/rfid_success.wav")
+                        AudioManager.play(SUCCESS_SOUND)
 
             except Exception as e:
                 print(f"Error in RFID listener: {e}")
@@ -252,7 +253,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 self.scroll_to_latest_entry()
 
             self.save()
-            AudioManager.play("shared/sounds/rfid_success.wav")
+            AudioManager.play(SUCCESS_SOUND)
 
 
     def scroll_to_latest_entry(self):
@@ -322,7 +323,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.table.insert('', END, values=(animal_id, rfid), tags='text_font')
         self.animals.append((animal_id, rfid))
 
-        AudioManager.play("shared/sounds/rfid_success.wav")
+        AudioManager.play(SUCCESS_SOUND)
 
         # Update entry text
         self.change_entry_text()
@@ -445,7 +446,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             bg_color="red",
             text_color="black"
         )
-        AudioManager.play("shared/sounds/error.wav")
+        AudioManager.play(ERROR_SOUND)
 
         message.mainloop()
 
@@ -787,6 +788,6 @@ class SerialSimulator():
         ok_button = CTkButton(message, text="OK", width=10, command=dismiss_warning)
         ok_button.grid(row=2, column=0, padx=10, pady=10)
 
-        AudioManager.play("shared/sounds/error.wav")
+        AudioManager.play(ERROR_SOUND)
 
         message.mainloop()

--- a/main.py
+++ b/main.py
@@ -17,21 +17,6 @@ from experiment_pages.create_experiment.new_experiment_ui import NewExperimentUI
 from experiment_pages.experiment.select_experiment_ui import ExperimentsUI
 from experiment_pages.experiment.test_screen import TestScreen
 
-# Function to resolve resource paths (must be defined before usage)
-def get_resource_path(relative_path):
-    ''' Get the absolute path to a resource. Works for development and PyInstaller executables. '''
-    try:
-        # Check if we're running as a PyInstaller bundle
-        if hasattr(sys, '_MEIPASS'):
-            # PyInstaller places all bundled files in _MEIPASS
-            return os.path.join(sys._MEIPASS, relative_path)
-        else:
-            # Return the absolute path when in development mode
-            return os.path.abspath(relative_path)  # Use absolute path in development mode
-    except Exception as e:
-        print(f"Error accessing resource: {relative_path}")
-        raise e
-
 rfid_serial_port_controller = SerialPortController("reader")
 
 TEMP_FOLDER_NAME = "Mouser"

--- a/shared/file_utils.py
+++ b/shared/file_utils.py
@@ -1,8 +1,8 @@
 '''Contains functions to create and save from temporary files.'''
 import tempfile
 import os
+import sys
 from shared.password_utils import PasswordManager
-from datetime import datetime
 
 
 TEMP_FOLDER_NAME = "Mouser"
@@ -74,18 +74,35 @@ def save_temp_to_encrypted(temp_file_path: str, permanent_file_path: str, passwo
     # Ensure paths are absolute and properly resolved
     temp_file_path = os.path.abspath(temp_file_path)
     permanent_file_path = os.path.abspath(permanent_file_path)
-    
+
     # Split the path into base and extension
     base, ext = os.path.splitext(permanent_file_path)
     # Take only the part before the first underscore if it exists
     base = base.split('_')[0]
     permanent_file_path = f"{base}{ext}"  # Updated line
-    
+
     manager = PasswordManager(password)
 
     manager.encrypt_file(temp_file_path)
     with open(temp_file_path, 'rb') as encrypted:
         data = encrypted.read()
-    
+
     with open(permanent_file_path, 'wb') as file:
         file.write(data)
+
+def get_resource_path(relative_path):
+    ''' Get the absolute path to a resource. Works for development and PyInstaller executables. '''
+    try:
+        # Check if we're running as a PyInstaller bundle
+        if hasattr(sys, '_MEIPASS'):
+            # PyInstaller places all bundled files in _MEIPASS
+            return os.path.join(sys._MEIPASS, relative_path)
+        else:
+            # Return the absolute path when in development mode
+            return os.path.abspath(relative_path)  # Use absolute path in development mode
+    except Exception as e:
+        print(f"Error accessing resource: {relative_path}")
+        raise e
+
+SUCCESS_SOUND = get_resource_path("shared/sounds/rfid_success.wav")
+ERROR_SOUND = get_resource_path("shared/sounds/error.wav")

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -185,7 +185,7 @@ class SerialPortController():
         '''Sets the setting of the serial port opened by converting the
         setting from csv file to actual setting used.'''
         from main import get_resource_path
-        preference_dir = get_resource_path(os.path.join(os.getcwd(), "settings", "serial ports", "preference"))
+        preference_dir = get_resource_path(os.path.join("settings", "serial ports", "preference"))
 
         if setting_type == "reader":
             setting_file = "rfid_config.txt"

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -36,7 +36,7 @@ class SerialPortController():
             else:
                 available_ports.append((f'{port_.device}', f'{port_.description}'))
         return available_ports
-    
+
     def get_available_ports_name(self):
         '''Returns a list of available system ports.'''
         available_ports = []
@@ -47,7 +47,7 @@ class SerialPortController():
             else:
                 available_ports.append(f'{port_.device}')
         return available_ports
-    
+
     def get_num_ports(self):
         '''Returns the number of available ports.'''
         return len(list(serial.tools.list_ports.comports()))
@@ -71,7 +71,7 @@ class SerialPortController():
         elif self.flow_control == 2:
             rtscts = True
 
-        self.writer_port = serial.Serial(port, baudrate=self.baud_rate, 
+        self.writer_port = serial.Serial(port, baudrate=self.baud_rate,
                                          bytesize=self.byte_size, parity=self.parity, stopbits=self.stop_bits
                                          ,xonxoff=xonoxoff, rtscts=rtscts, timeout = 1 )
         self.ports_in_used.append(self.writer_port)
@@ -85,7 +85,7 @@ class SerialPortController():
         elif self.flow_control == 2:
             rtscts = True
 
-        self.reader_port = serial.Serial(port, baudrate=self.baud_rate, 
+        self.reader_port = serial.Serial(port, baudrate=self.baud_rate,
                                          bytesize=self.byte_size, parity=self.parity, stopbits=self.stop_bits
                                          ,xonxoff=xonoxoff, rtscts=rtscts, timeout = 1 )
         self.ports_in_used.append(self.reader_port)
@@ -182,10 +182,11 @@ class SerialPortController():
             print(e)
 
     def retrieve_setting(self, setting_type):
-        '''Sets the setting of the serial port opened by converting the 
+        '''Sets the setting of the serial port opened by converting the
         setting from csv file to actual setting used.'''
-        preference_dir = os.path.join(os.getcwd(), "settings", "serial ports", "preference")
-        
+        from main import get_resource_path
+        preference_dir = get_resource_path(os.path.join(os.getcwd(), "settings", "serial ports", "preference"))
+
         if setting_type == "reader":
             setting_file = "rfid_config.txt"
             setting_folder = "reader"

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -11,6 +11,7 @@ nothing even if you write to writer port already
 import os
 import serial
 import serial.tools.list_ports
+from shared.file_utils import get_resource_path
 
 class SerialPortController():
     '''Serial Port control functions.'''
@@ -184,7 +185,6 @@ class SerialPortController():
     def retrieve_setting(self, setting_type):
         '''Sets the setting of the serial port opened by converting the
         setting from csv file to actual setting used.'''
-        from main import get_resource_path
         preference_dir = get_resource_path(os.path.join("settings", "serial ports", "preference"))
 
         if setting_type == "reader":
@@ -197,7 +197,7 @@ class SerialPortController():
             print("Invalid setting type. Must be 'reader' or 'device'.")
             return
 
-        preference_path = os.path.join(preference_dir, setting_folder, setting_file)
+        preference_path = get_resource_path(os.path.join(preference_dir, setting_folder, setting_file))
         print(f"🔍 Looking for settings in: {preference_path}")
 
         if not os.path.exists(preference_path):
@@ -207,7 +207,7 @@ class SerialPortController():
         try:
             with open(preference_path, "r") as file:
                 settings_file_name = file.readline().strip()
-                settings_path = os.path.join(os.getcwd(), "settings", "serial ports", settings_file_name)
+                settings_path = get_resource_path(os.path.join("settings", "serial ports", settings_file_name))
 
                 if not os.path.exists(settings_path):
                     print(f"Settings file {settings_path} not found.")

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -35,7 +35,7 @@ class SerialPortSetting(SettingPage):
 
         read_path = self.get_read_path()
         write_path = self.get_write_path()
-        self.port_setting_configuration_path = os.path.join(write_path, "settings", "serial ports")
+        self.port_setting_configuration_path = get_resource_path(os.path.join(write_path, "settings", "serial ports"))
 
 
         # setting value element
@@ -49,9 +49,9 @@ class SerialPortSetting(SettingPage):
 
         if preference:
             if preference == "device":
-                self.preference_path = os.path.join(read_path, "settings", "serial ports", "preference", "device", "preferred_config.txt")
+                self.preference_path = get_resource_path(os.path.join(read_path, "settings", "serial ports", "preference", "device", "preferred_config.txt"))
             elif preference == "reader":
-                self.preference_path = os.path.join(read_path, "settings", "serial ports", "preference", "reader", "rfid_config.txt")
+                self.preference_path = get_resource_path(os.path.join(read_path, "settings", "serial ports", "preference", "reader", "rfid_config.txt"))
 
             else:
                 self.preference_path = None  # Fallback if no valid type
@@ -83,8 +83,8 @@ class SerialPortSetting(SettingPage):
         self.summary_page("Serial Settings")
 
         self.available_configuration = []
-        read_config_path = os.path.join(self.get_read_path(), "settings", "serial ports")
-        write_config_path = os.path.join(self.get_write_path(), "settings", "serial ports")
+        read_config_path = get_resource_path(os.path.join(self.get_read_path(), "settings", "serial ports"))
+        write_config_path = get_resource_path(os.path.join(self.get_write_path(), "settings", "serial ports"))
 
         # Read from both
         for path in [read_config_path, write_config_path]:
@@ -300,10 +300,10 @@ class SerialPortSetting(SettingPage):
 
         base_path = self.get_write_path()
 
-        settings_dir = os.path.join(base_path, "settings", "serial ports")
+        settings_dir = get_resource_path(os.path.join(base_path, "settings", "serial ports"))
         os.makedirs(settings_dir, exist_ok=True)
 
-        settings_path = os.path.join(settings_dir, f"{configuration_name}.csv")
+        settings_path = get_resource_path(os.path.join(settings_dir, f"{configuration_name}.csv"))
 
         try:
             with open(settings_path, "w", newline="", encoding="utf-8") as file:
@@ -337,9 +337,9 @@ class SerialPortSetting(SettingPage):
         '''Save a specific configuration for a given port in its own preference folder.'''
         base_path = self.get_write_path()
 
-        preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "device")
+        preference_dir = get_resource_path(os.path.join(base_path, "settings", "serial ports", "preference", "device"))
         os.makedirs(preference_dir, exist_ok=True)
-        preference_path = os.path.join(preference_dir, "preferred_config.txt")
+        preference_path = get_resource_path(os.path.join(preference_dir, "preferred_config.txt"))
 
         try:
             with open(preference_path, "w") as file:
@@ -352,9 +352,9 @@ class SerialPortSetting(SettingPage):
         '''Save a specific configuration for a given port in its own preference folder.'''
         base_path = self.get_write_path()
 
-        preference_dir = os.path.join(base_path, "settings", "serial ports", "preference", "reader")
+        preference_dir = get_resource_path(os.path.join(base_path, "settings", "serial ports", "preference", "reader"))
         os.makedirs(preference_dir, exist_ok=True)
-        preference_path = os.path.join(preference_dir, "rfid_config.txt")
+        preference_path = get_resource_path(os.path.join(preference_dir, "rfid_config.txt"))
 
         try:
             with open(preference_path, "w") as file:
@@ -368,17 +368,17 @@ class SerialPortSetting(SettingPage):
         read_path = self.get_read_path()
         write_path = self.get_write_path()
 
-        read_config_dir = os.path.join(read_path, "settings", "serial ports")
-        write_config_dir = os.path.join(write_path, "settings", "serial ports")
+        read_config_dir = get_resource_path(os.path.join(read_path, "settings", "serial ports"))
+        write_config_dir = get_resource_path(os.path.join(write_path, "settings", "serial ports"))
 
         if f:
             file_name = f
         else:
             file_name = self.current_configuration_name.get()
 
-        full_path = os.path.join(write_config_dir, file_name)
+        full_path = get_resource_path(os.path.join(write_config_dir, file_name))
         if not os.path.exists(full_path):
-            full_path = os.path.join(read_config_dir, file_name)
+            full_path = get_resource_path(os.path.join(read_config_dir, file_name))
 
         try:
             with open(full_path) as file:


### PR DESCRIPTION
Fixes #315 

Moved the commonly used get_resource_path method from main to the shared/file.utils so that all files can use this method without circular imports from main

Added global variables SUCCESS and ERROR sound that use get_resource_path so that other files can simply import these variables and the sounds will use the proper file path, even in the .exe 

Wrapped file paths for serial settings with get_resource_path method so that serial setting file paths are understood correctly in the .exe 

All sounds and serial settings tested within the .exe and function properly.

Updated GH Action to only create executable in the appropriate branches
