### PR TITLE
Add Measurement Fix and Export Options

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -496,7 +496,7 @@ class ChangeMeasurementsDialog():
                         current_index = self.animal_ids.index(animal_id)
 
                         while current_index < len(self.animal_ids) and self.thread_running:
-                            if len(data_handler.received_data) >= 2:  # Customize condition
+                            if len(data_handler.received_data) >= 2 and data_handler.received_data != " " and data_handler.received_data is not None and data_handler.received_data != 0:
                                 received_data = data_handler.get_stored_data()
                                 entry.insert(1, received_data)
                                 data_handler.stop()


### PR DESCRIPTION
Fixes #316 

**What was changed?**

This merge fixes the add measurement method as well as adding an additional export option for testing purposes. 

**Why was it changed?**

The issue is to ensure that different lab devices work regardless of the number of blank inputs sent around the actual data, as well as ensuring the entries are added to the database without error. 

**How was it changed?**

The experiment database class had been modified to ensure the export data functions are correct and named correctly, as well as the add measurement to allow for them to filtered if they are marked for use via group configuration. 
