### PR TITLE
Additional Threading on Data Collection + Related

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -325,22 +325,45 @@ class DataCollectionUI(MouserPage):
 
     def handle_measurement(self, value):
         '''Handle incoming measurement value by updating the dialog and closing it.'''
-        if self.changer_open and self.current_animal_id:
-            # If measurement is auto, directly submit the value
-            if self.database.get_measurement_type() == 1:
-                # Submit the value (updates database and table)
-                self.change_selected_value(self.current_animal_id, [value])
-                AudioManager.play(SUCCESS_SOUND)
+        if not self.current_animal_id:
+            # No animal selected when measurement came in
+            FlashOverlay(
+                parent=self,
+                message="Please scan an animal first!",
+                duration=2000,
+                bg_color="#FF0000",  # Red to indicate error
+                text_color="black"
+            )
+            AudioManager.play(ERROR_SOUND)
+            return
 
-                # Close the dialog after processing the measurement
-                self.changer.close()
-                self.changer_open = False
+        if not self.changer_open:
+            # Animal is selected but dialog isn't open
+            FlashOverlay(
+                parent=self,
+                message="Please wait for dialog to open...",
+                duration=2000,
+                bg_color="#FF0000",
+                text_color="black"
+            )
+            AudioManager.play(ERROR_SOUND)
+            return
 
-                # Flash a notification that measurement was recorded
-                FlashOverlay(
-                    parent=self,
-                    message=f"Measurement Recorded: {value}",
-                    duration=1000,
+        # If measurement is auto, directly submit the value
+        if self.database.get_measurement_type() == 1:
+            # Submit the value (updates database and table)
+            self.change_selected_value(self.current_animal_id, [value])
+            AudioManager.play(SUCCESS_SOUND)
+
+            # Close the dialog after processing the measurement
+            self.changer.close()
+            self.changer_open = False
+
+            # Flash a notification that measurement was recorded
+            FlashOverlay(
+                parent=self,
+                message=f"Measurement Recorded: {value}",
+                duration=1000,
                     bg_color="#00FF00",  # Bright Green
                     text_color="black"
                 )

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -155,7 +155,6 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
 
     def disable_buttons_if_needed(self):
         '''Disables Data Collection and Data Export buttons if RFIDs are not yet mapped.'''
-    # This method disables all buttons except for the Map RFID button until all specimens have an associated RFID
         self.group_button.configure(state="normal")
         if self.experiment.experiment_uses_rfid() == 1:
             if not self.all_rfid_mapped():
@@ -166,6 +165,8 @@ class ExperimentMenuUI(MouserPage): #pylint: disable= undefined-variable
                 self.analysis_button.configure(state="normal")
         else:
             self.rfid_button.configure(state="disabled")
+            # Enable collection button for non-RFID experiments
+            self.collection_button.configure(state="normal")
 
 
     def on_show_frame(self):

--- a/shared/flash_overlay.py
+++ b/shared/flash_overlay.py
@@ -1,38 +1,71 @@
-'''Custom Flash Screen to show statuses to the user'''
+'''Flash Overlay module for displaying temporary messages.'''
+import threading
 from customtkinter import *
 
 class FlashOverlay:
-    '''A reusable flash overlay that can be used to show temporary full-screen messages'''
-
-    def __init__(self, parent: CTk, message: str, duration: int = 1000,
-                 bg_color: str = "#00FF00", text_color: str = "white",
-                 font: tuple = ("Arial", 32, "bold")):
-
+    '''A reusable flash overlay that can be used to show temporary full-screen messages'''    def __init__(self, parent, message, duration=1000, bg_color="#00FF00", text_color="black"):
+        self._lock = threading.Lock()
         self.parent = parent
+        self.message = message
         self.duration = duration
+        self.bg_color = bg_color
+        self.text_color = text_color
+        self.overlay = None
+        self._create_overlay()
 
-        # Create flash overlay frame
-        self.flash_frame = CTkFrame(parent, fg_color=bg_color)
-        self.flash_frame.place(relx=0, rely=0, relwidth=1, relheight=1)
+    def _create_overlay(self):
+        '''Creates and displays the overlay message.'''
+        with self._lock:
+            # Create the overlay frame
+            self.overlay = CTkFrame(self.parent)
+            self.overlay.place(relx=0.5, rely=0.5, anchor=CENTER)
 
-        # Add message
-        self.label = CTkLabel(
-            self.flash_frame,
-            text=message,
-            font=font,
-            text_color=text_color
-        )
-        self.label.place(relx=0.5, rely=0.5, anchor=CENTER)
+            # Create the message label
+            label = CTkLabel(
+                self.overlay,
+                text=self.message,
+                font=("Arial", 24, "bold"),
+                bg_color=self.bg_color,
+                text_color=self.text_color,
+                corner_radius=10
+            )
+            label.pack(padx=20, pady=20)
 
-        # Schedule the fade out
-        self.parent.after(self.duration, self._fade_out)
+            # Schedule the removal of the overlay
+            self.parent.after(self.duration, self.remove)
 
-    def _fade_out(self):
-        '''Removes the flash overlay'''
-        if self.flash_frame.winfo_exists():
-            self.flash_frame.destroy()
+    def remove(self):
+        '''Removes the overlay from the screen.'''
+        with self._lock:
+            if self.overlay and self.overlay.winfo_exists():
+                try:
+                    self.overlay.destroy()
+                except Exception as e:
+                    print(f"Error removing overlay: {e}")
+                finally:
+                    self.overlay = None
 
-    def destroy(self):
-        '''Manually destroy the overlay before the duration'''
-        if self.flash_frame.winfo_exists():
-            self.flash_frame.destroy()
+    def update_message(self, new_message, new_duration=None):
+        '''Updates the message and optionally the duration.'''
+        with self._lock:
+            if self.overlay and self.overlay.winfo_exists():
+                # Update the message
+                for widget in self.overlay.winfo_children():
+                    if isinstance(widget, CTkLabel):
+                        widget.configure(text=new_message)
+
+                # Update duration if provided
+                if new_duration is not None:
+                    self.duration = new_duration
+                    # Cancel existing removal and schedule new one
+                    self.parent.after_cancel(self.overlay.after_id)
+                    self.parent.after(self.duration, self.remove)
+
+    def is_visible(self):
+        '''Returns whether the overlay is currently visible.'''
+        with self._lock:
+            return self.overlay is not None and self.overlay.winfo_exists()
+
+    def force_remove(self):
+        '''Forces immediate removal of the overlay.'''
+        self.remove()

--- a/shared/flash_overlay.py
+++ b/shared/flash_overlay.py
@@ -3,7 +3,8 @@ import threading
 from customtkinter import *
 
 class FlashOverlay:
-    '''A reusable flash overlay that can be used to show temporary full-screen messages'''    def __init__(self, parent, message, duration=1000, bg_color="#00FF00", text_color="black"):
+    '''A reusable flash overlay that can be used to show temporary full-screen messages'''
+    def __init__(self, parent, message, duration=1000, bg_color="#00FF00", text_color="black"):
         self._lock = threading.Lock()
         self.parent = parent
         self.message = message
@@ -16,20 +17,22 @@ class FlashOverlay:
     def _create_overlay(self):
         '''Creates and displays the overlay message.'''
         with self._lock:
-            # Create the overlay frame
+            # Create the overlay frame that covers the entire parent window
             self.overlay = CTkFrame(self.parent)
-            self.overlay.place(relx=0.5, rely=0.5, anchor=CENTER)
+            self.overlay.place(relx=0, rely=0, relwidth=1, relheight=1)  # Cover entire parent
+
+            # Create a semi-transparent background
+            self.overlay.configure(fg_color=self.bg_color)
 
             # Create the message label
             label = CTkLabel(
                 self.overlay,
                 text=self.message,
                 font=("Arial", 24, "bold"),
-                bg_color=self.bg_color,
                 text_color=self.text_color,
                 corner_radius=10
             )
-            label.pack(padx=20, pady=20)
+            label.place(relx=0.5, rely=0.5, anchor=CENTER)  # Center the message
 
             # Schedule the removal of the overlay
             self.parent.after(self.duration, self.remove)

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -11,6 +11,7 @@ nothing even if you write to writer port already
 import os
 import serial
 import serial.tools.list_ports
+import threading
 from shared.file_utils import get_resource_path
 
 class SerialPortController():
@@ -24,6 +25,7 @@ class SerialPortController():
         self.flow_control = None
         self.writer_port = None
         self.reader_port = None
+        self._lock = threading.Lock()  # Add thread lock
         print(f"🔍 Initializing SerialPortController with setting type: {setting_type}")
         self.retrieve_setting(setting_type)
 
@@ -64,43 +66,70 @@ class SerialPortController():
         return virtual_ports
 
     def set_writer_port(self, port: str):
-        '''Sets the specified port as the writing port.'''
-        xonoxoff = False
-        rtscts = False
-        if self.flow_control == 1:
-            xonoxoff = True
-        elif self.flow_control == 2:
-            rtscts = True
+        '''Thread-safe method to set the writer port.'''
+        with self._lock:
+            xonoxoff = False
+            rtscts = False
+            if self.flow_control == 1:
+                xonoxoff = True
+            elif self.flow_control == 2:
+                rtscts = True
 
-        self.writer_port = serial.Serial(port, baudrate=self.baud_rate,
-                                         bytesize=self.byte_size, parity=self.parity, stopbits=self.stop_bits
-                                         ,xonxoff=xonoxoff, rtscts=rtscts, timeout = 1 )
-        self.ports_in_used.append(self.writer_port)
+            try:
+                self.writer_port = serial.Serial(port, baudrate=self.baud_rate,
+                                             bytesize=self.byte_size, parity=self.parity,
+                                             stopbits=self.stop_bits,
+                                             xonxoff=xonoxoff, rtscts=rtscts, timeout=1)
+                self.ports_in_used.append(self.writer_port)
+            except serial.SerialException as e:
+                print(f"Error setting writer port: {e}")
+                raise
 
     def set_reader_port(self, port: str):
-        '''Sets the specified port as the reading port.'''
-        xonoxoff = False
-        rtscts = False
-        if self.flow_control == 1:
-            xonoxoff = True
-        elif self.flow_control == 2:
-            rtscts = True
+        '''Thread-safe method to set the reader port.'''
+        with self._lock:
+            xonoxoff = False
+            rtscts = False
+            if self.flow_control == 1:
+                xonoxoff = True
+            elif self.flow_control == 2:
+                rtscts = True
 
-        self.reader_port = serial.Serial(port, baudrate=self.baud_rate,
-                                         bytesize=self.byte_size, parity=self.parity, stopbits=self.stop_bits
-                                         ,xonxoff=xonoxoff, rtscts=rtscts, timeout = 1 )
-        self.ports_in_used.append(self.reader_port)
+            try:
+                self.reader_port = serial.Serial(port, baudrate=self.baud_rate,
+                                             bytesize=self.byte_size, parity=self.parity,
+                                             stopbits=self.stop_bits,
+                                             xonxoff=xonoxoff, rtscts=rtscts, timeout=1)
+                self.ports_in_used.append(self.reader_port)
+            except serial.SerialException as e:
+                print(f"Error setting reader port: {e}")
+                raise
 
     def close_writer_port(self):
-        '''Closes the writer port if it exists.'''
-        if self.writer_port is not None:
-            self.writer_port.close()
+        '''Thread-safe method to close the writer port.'''
+        with self._lock:
+            if self.writer_port is not None:
+                try:
+                    self.writer_port.close()
+                    if self.writer_port in self.ports_in_used:
+                        self.ports_in_used.remove(self.writer_port)
+                except Exception as e:
+                    print(f"Error closing writer port: {e}")
+                finally:
+                    self.writer_port = None
 
     def close_reader_port(self):
-        '''Closes the reader port if it exists.'''
-        if self.reader_port is not None:
-            self.reader_port.close()
-
+        '''Thread-safe method to close the reader port.'''
+        with self._lock:
+            if self.reader_port is not None:
+                try:
+                    self.reader_port.close()
+                    if self.reader_port in self.ports_in_used:
+                        self.ports_in_used.remove(self.reader_port)
+                except Exception as e:
+                    print(f"Error closing reader port: {e}")
+                finally:
+                    self.reader_port = None
     def open_reader_port(self, port_name):
         '''Open the reader port with the specified settings.'''
         try:
@@ -124,42 +153,46 @@ class SerialPortController():
             return None
 
     def read_data(self):
-        '''Returns the data read from the reader port as a string.'''
-        port = self.reader_port
-        baudrate = self.baud_rate
-        bytesize = self.byte_size
-        parity = self.parity
-        stopbits = self.stop_bits
-        ser = serial.Serial(port, baudrate, bytesize, parity, stopbits)
-
-        if self.reader_port:
+        '''Thread-safe method to read from the reader port.'''
+        with self._lock:
+            if self.reader_port is None or not self.reader_port.is_open:
+                raise serial.SerialException("Reader port is not open")
             try:
-                reader_data = ser.read(19)
-                second_measurement = reader_data[10:20]
-                decoded_second_measurement = second_measurement.decode('ascii')
-                print(reader_data)
-                print(second_measurement)
-                print(decoded_second_measurement)
-                return decoded_second_measurement
-            except Exception as e:
-                print(f"Error reading from serial port: {e}")
+                reader_data = self.reader_port.read(19)
+                if reader_data:
+                    second_measurement = reader_data[10:20]
+                    return second_measurement.decode('ascii')
                 return None
-            finally:
-                ser.close()
+            except Exception as e:
+                print(f"Error reading from port: {e}")
+                raise
 
     def write_to(self, message: str):
-        '''Writes message to the writer port as bytes.'''
-        byte_message = message.encode()
-        self.writer_port.write(byte_message)
+        '''Thread-safe method to write to the writer port.'''
+        with self._lock:
+            if self.writer_port is None or not self.writer_port.is_open:
+                raise serial.SerialException("Writer port is not open")
+            try:
+                byte_message = message.encode()
+                self.writer_port.write(byte_message)
+            except Exception as e:
+                print(f"Error writing to port: {e}")
+                raise
 
     def close_all_ports(self):
-        '''Closes all ports in use.'''
-        hold = self.ports_in_used
-        for port_ in hold:
-            port_.close()
-            self.ports_in_used.remove(port_)
-        self.close_reader_port()
-        self.close_writer_port()
+        '''Thread-safe method to close all ports.'''
+        with self._lock:
+            try:
+                for port in self.ports_in_used[:]:  # Create a copy of the list
+                    try:
+                        port.close()
+                    except Exception as e:
+                        print(f"Error closing port: {e}")
+                self.ports_in_used.clear()
+                self.close_reader_port()
+                self.close_writer_port()
+            except Exception as e:
+                print(f"Error in close_all_ports: {e}")
 
     def get_reader_port(self):
         '''Returns the reader port.'''


### PR DESCRIPTION
Fixes #319 

**What was changed?**

The Data Collection screen has been modified to always be listening to both the serial input device as well as the RFID reader, each on their own thread, while leaving the main thread open for user input. Related files and methods were also updated to ensure thread safety throughout the program.

**Why was it changed?**

This was changed for several reasons. First, the client would like to be able to scan multiple animals without having to do extra steps while on the data collection screen. In addition, it ensures threads are only running for the things they need to be and, with the addition of the extra thread safe methods, keeps the program in a much more overall stable state with (hopefully) less crashes. 

**How was it changed?**

Data_collection has been changed to have two always running continuous threads- one for the RFID device and one for the serial device. These threads interact with the main program in safe ways, ensuring they are not accessing the same pieces of information at the same time. In addition, other files such as the experiment database, flash overlay, and serial device controller have been changed to support the new thread safe methods of access. 

