### PR TITLE
Add workflow to trigger reusable build and generate downloadable Windows Executable

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,12 +1,18 @@
 name: Build Mouser Windows Executable
 
 on:
-  workflow_dispatch:       # allows manual runs
-  pull_request:            # runs on PR
-  push:                    # runs on pushes to main
+  workflow_dispatch:
+  pull_request:
+  push:
     branches: [ main ]
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
 
 jobs:
   build-windows:
     uses: ./.github/workflows/build-reusable.yml
+    secrets: inherit
     with: {}


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (build-windows.yml) that calls the existing build-reusable.yml file to automatically build and package the Mouser Windows executable. The goal is to enable maintainers and contributors to download the latest .exe build directly from GitHub Actions for testing and validation which does not require any local setup or impacting production code.

Key Changes

1. Added .github/workflows/build-windows.yml
2. Configured workflow to trigger on push, pull request, and manual runs, call the existing reusable workflow (build-reusable.yml)
and upload the built executable as an artifact for easy access