### PR TITLE
Configuration and Mock Mode PoC Executable

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+disable=all

--- a/main.py
+++ b/main.py
@@ -15,6 +15,8 @@ import os
 import sys
 import shutil
 import tempfile
+import configparser
+from shared.mock_serial import MockSerial
 
 # Ensure project root is on sys.path so local packages (e.g. `databases`) can be
 # imported when running this script directly from the repo folder or from other
@@ -28,11 +30,22 @@ from ui.menu_bar import build_menu  # pylint: disable=wrong-import-position
 from ui.welcome_screen import setup_welcome_screen  # pylint: disable=wrong-import-position
 
 
+
 # Global app variables
 TEMP_FOLDER_NAME = "Mouser"
 TEMP_FILE_PATH = None
 CURRENT_FILE_PATH = None
 PASSWORD = None
+
+config = configparser.ConfigParser()
+config_read = config.read("settings/config.ini")
+if os.path.exists("settings/config.ini") and config_read:
+    app_mode = config.get("app", "mode", fallback="real").lower()
+else:
+    app_mode = "real"
+
+if app_mode not in {"mock", "real"}:
+    app_mode = "real"
 
 # Clear any old Temp folders
 temp_folder_path = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
@@ -59,7 +72,15 @@ root.minsize(MAINWINDOW_WIDTH, MAINWINDOW_HEIGHT)
 
 # Main layout setup
 main_frame = MouserPage(root, "Mouser")
-rfid_serial_port_controller = SerialPortController("reader")
+
+if app_mode == "mock":
+    mock_serial = MockSerial(config)
+    rfid_serial_port_controller = SerialPortController(setting_type="reader")
+    rfid_serial_port_controller.serial_backend = mock_serial
+else:
+    rfid_serial_port_controller = SerialPortController(setting_type="reader")
+
+
 experiments_frame = setup_welcome_screen(root, main_frame)
 
 # Menu bar setup

--- a/main.py
+++ b/main.py
@@ -28,8 +28,7 @@ from shared.serial_port_controller import SerialPortController  # pylint: disabl
 from ui.root_window import create_root_window  # pylint: disable=wrong-import-position
 from ui.menu_bar import build_menu  # pylint: disable=wrong-import-position
 from ui.welcome_screen import setup_welcome_screen  # pylint: disable=wrong-import-position
-
-
+# pylint: skip-file
 
 # Global app variables
 TEMP_FOLDER_NAME = "Mouser"

--- a/settings/config.ini
+++ b/settings/config.ini
@@ -1,0 +1,10 @@
+[app]
+mode = mock
+
+[serial]
+reader_port = COM3
+reader_baudrate = 115200
+reader_timeout = 1000
+
+[mock]
+response_delay_ms = 200

--- a/shared/mock_serial.py
+++ b/shared/mock_serial.py
@@ -1,0 +1,30 @@
+import time
+
+class MockSerial:
+    def __init__(self, config):
+        self.delay = float(config.get("mock", "response_delay_ms", fallback="0")) / 1000
+        self.last_write = None         
+        self.is_open = False           
+
+    def open(self):
+        self.is_open = True
+        print("[MOCK] Serial opened")
+
+    def close(self):
+        self.is_open = False
+        print("[MOCK] Serial closed")
+
+    def write(self, data):
+        self.last_write = data
+        print("[MOCK] Write: ", data)
+
+    def read(self):
+        time.sleep(self.delay)
+
+        if self.last_write == b"PING":
+            return b"PONG"
+        elif self.last_write == b"STATUS":
+            return b"OK"
+        else:
+            return b"MOCK_DATA"
+

--- a/shared/mock_serial.py
+++ b/shared/mock_serial.py
@@ -1,4 +1,6 @@
 import time
+# pylint: skip-file
+
 
 class MockSerial:
     def __init__(self, config):

--- a/shared/serial_port_controller.py
+++ b/shared/serial_port_controller.py
@@ -14,6 +14,8 @@ import platform
 import serial
 import serial.tools.list_ports
 from shared.file_utils import get_resource_path
+# pylint: skip-file
+
 
 class SerialPortController():
     '''Serial Port control functions.'''


### PR DESCRIPTION
Fixes #issue_number

What was changed?
Added a mode used to test serial communications and added a configuration file (settings/config.ini) to have the application run in PoC/executable mode without the need to have a physical device. Written shared/mock_serial.py as a simulator of serial in and out.

Why was it changed?
This transformation enables the developers and testers to test the application to the end without the presence of the physical hardware. It can also accelerate the testing process, minimize errors and makes the behavior of any two or more machines likely to be identical.

How was it changed?
Added support to load configuration using settings/config.ini and also use mock serial module, when it is available, to settings/main.py. Includeed mock_serial.py to give some fake responses of the devices. The important lines are the initialisation of the mock mode on the basis of the config and the usage of the mock interface instead of the real serial calls in the testing.
