### PR TITLE
RFID mapping is working inside the Map RFID page.

### DIFF
--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -504,6 +504,11 @@ class ExperimentDatabase:
         result = self._c.fetchone()
         return result[0] if result else 0  # Default to manual (0)
 
+    def update_measurement_type(self, measurement_type):
+        '''Updates measurement_type in the experiment table.'''
+        self._c.execute("UPDATE experiment SET measurement_type = ?", (measurement_type,))
+        self._conn.commit()
+
     def get_all_animal_ids(self):
         '''Returns a list of all active animal IDs that have RFIDs mapped to them.'''
         self._c.execute('''
@@ -527,6 +532,7 @@ class ExperimentDatabase:
         """
         Exports the experiment data into a structured CSV:
         1. Experiment metadata
+        2. Animals table with RFID mappings
         3. Groups table with header
         """
         import os
@@ -574,6 +580,11 @@ class ExperimentDatabase:
             experiment_df.to_csv(f, index=False)
             f.write("\n")
 
+            # Write animals section to always include animal_id/rfid mapping
+            f.write("### Table: animals ###\n")
+            animals_df.to_csv(f, index=False)
+            f.write("\n")
+
             # Write measurement matrix
             pivot_df.to_csv(f, index=False)
             f.write("\n")
@@ -616,6 +627,21 @@ class ExperimentDatabase:
 
     def set_animal_active_status(self, animal_id, status):
         '''Sets the active status of an animal.'''
+        self._c.execute("SELECT group_id, active FROM animals WHERE animal_id = ?", (animal_id,))
+        row = self._c.fetchone()
+        if row:
+            group_id, current_status = row
+            if int(current_status) != int(status):
+                if int(status) == 0:
+                    self._c.execute(
+                        "UPDATE groups SET num_animals = CASE WHEN num_animals > 0 THEN num_animals - 1 ELSE 0 END WHERE group_id = ?",
+                        (group_id,),
+                    )
+                else:
+                    self._c.execute(
+                        "UPDATE groups SET num_animals = num_animals + 1 WHERE group_id = ?",
+                        (group_id,),
+                    )
         self._c.execute("UPDATE animals SET active = ? WHERE animal_id = ?", (status, animal_id))
         self._conn.commit()
 

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -184,12 +184,12 @@ class ExperimentMenuUI(MouserPage):
 
         exp.group_num_changed = False
         exp.measurement_items_changed = False
-        exp.data_collect_type = 0
+        exp.data_collect_type = db.get_measurement_type()
 
         def save_group_config(updated_experiment):
             group_names = updated_experiment.get_group_names()
-            if group_names:
-                db.update_group_names(group_names)
+            db.update_group_names(group_names)
+            db.update_measurement_type(updated_experiment.get_measurement_type())
 
         from experiment_pages.experiment.group_config_ui import (  # pylint: disable=import-error,import-outside-toplevel
             GroupConfigUI,

--- a/experiment_pages/experiment/group_config_ui.py
+++ b/experiment_pages/experiment/group_config_ui.py
@@ -166,7 +166,8 @@ class GroupConfigUI(MouserPage):
             font=("Segoe UI", 18, "bold"),
         ).grid(row=0, column=0, columnspan=3, pady=10)
 
-        self.type = BooleanVar(value=True)
+        initial_value = self.experiment.get_measurement_type()
+        self.type = BooleanVar(value=(initial_value != 0))
         self.button_vars.append(self.type)
 
         CTkLabel(
@@ -212,7 +213,7 @@ class GroupConfigUI(MouserPage):
 
     def save_experiment(self):
         '''Saves all entered group names and input method.'''
-        group_names = [entry.get().strip() for entry in self.group_input if entry.get().strip()]
+        group_names = [entry.get().strip() for entry in self.group_input]
         self.experiment.group_names = group_names
         self.experiment.data_collect_type = 1 if self.button_vars[0].get() else 0
         if callable(self.save_callback):

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -92,6 +92,9 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.rfid_thread = None # Store running thread
         self.hid_listener = None
         self.use_hid_fallback = False
+        self._serial_first_data_timeout = 8.0
+        self._recent_tag = None
+        self._recent_tag_time = 0.0
 
         # Store the parent reference
         self.parent = parent
@@ -115,7 +118,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.start_rfid = CTkButton(self, text="Start Scanning", compound=TOP,
                                          width=250, height=75, font=("Georgia", 65), command=self.rfid_listen)
         self.start_rfid.place(relx=0.45, rely=0.15, anchor=CENTER)
-        if self.db.experiment_uses_rfid == 0:
+        if self.db.experiment_uses_rfid() == 0:
             self.start_rfid.configure(state="disabled")
 
         self.table_frame = CTkFrame(self)
@@ -214,18 +217,11 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         serial_reader = getattr(self.rfid_reader, "reader", None)
         serial_port = getattr(serial_reader, "ser", None)
         if serial_port is None:
-            try:
-                self.rfid_reader.stop()
-            except Exception:
-                pass
-            self.rfid_reader = None
-            print("⚠️ Serial RFID unavailable. Switching to HID fallback.")
-            self.use_hid_fallback = True
-            self._start_hid_listener()
+            self._switch_to_hid_fallback("Serial RFID unavailable.")
             return
 
         self.use_hid_fallback = False
-        self._stop_hid_listener()
+        self._start_hid_listener(show_flash=False)
 
         def listen():
             try:
@@ -233,14 +229,27 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 print("🔄 RFID Reader Started!")
 
                 last_rfid = None
+                serial_start_time = time.monotonic()
+                got_first_serial_data = False
 
                 while not self.rfid_stop_event.is_set():
+                    serial_reader = getattr(self.rfid_reader, "reader", None)
+                    serial_port = getattr(serial_reader, "ser", None)
+                    if serial_port is None or not getattr(serial_port, "is_open", False):
+                        self.after(0, lambda: self._switch_to_hid_fallback("Serial connection lost."))
+                        return
+
                     received_rfid = self.rfid_reader.get_stored_data()
+                    elapsed = time.monotonic() - serial_start_time
+                    if (not got_first_serial_data) and (not received_rfid) and elapsed > self._serial_first_data_timeout:
+                        self.after(0, lambda: self._switch_to_hid_fallback("No serial RFID data received."))
+                        return
 
                     if not received_rfid or received_rfid == last_rfid:
                         time.sleep(0.5)
                         continue
 
+                    got_first_serial_data = True
                     last_rfid = received_rfid
                     print(f"📡 RFID Scanned: {received_rfid}")
                     self.after(0, lambda value=received_rfid: self._handle_scanned_rfid(value))
@@ -280,23 +289,40 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
         time.sleep(0.5)  # Allow OS to release the port
 
-    def _start_hid_listener(self):
+    def _switch_to_hid_fallback(self, reason=""):
+        """Stop serial reading and switch to HID fallback mode."""
+        if reason:
+            print(f"⚠️ {reason} Switching to HID fallback.")
+
+        if self.rfid_reader:
+            try:
+                self.rfid_reader.stop()
+            except Exception:
+                pass
+            finally:
+                self.rfid_reader = None
+
+        self.use_hid_fallback = True
+        self._start_hid_listener()
+
+    def _start_hid_listener(self, show_flash=True):
         """Start HID keyboard-wedge fallback listener."""
         self._stop_hid_listener()
 
         def on_tag(tag):
             self._handle_scanned_rfid(tag)
 
-        self.hid_listener = HIDWedgeListener(self, on_tag=on_tag)
+        self.hid_listener = HIDWedgeListener(self, on_tag=on_tag, capture_all=True)
         self.hid_listener.start()
-        self.focus_force()
-        FlashOverlay(
-            parent=self,
-            message="HID Fallback Active: Scan tag then press Enter",
-            duration=2000,
-            bg_color="#FDE68A",
-            text_color="black"
-        )
+        self.parent.focus_force()
+        if show_flash:
+            FlashOverlay(
+                parent=self,
+                message="HID Fallback Active: Scan tag then press Enter",
+                duration=2000,
+                bg_color="#FDE68A",
+                text_color="black"
+            )
 
     def _stop_hid_listener(self):
         """Stop HID keyboard-wedge fallback listener."""
@@ -316,6 +342,12 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             print("⚠️ Empty or invalid RFID detected, skipping...")
             return
 
+        now = time.monotonic()
+        if clean_rfid == self._recent_tag and (now - self._recent_tag_time) < 0.35:
+            return
+        self._recent_tag = clean_rfid
+        self._recent_tag_time = now
+
         if clean_rfid in self.animal_rfid_list:
             print(f"⚠️ RFID {clean_rfid} is already in use! Skipping...")
             AudioManager.play(ERROR_SOUND)
@@ -323,7 +355,6 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             return
 
         self.add_value(clean_rfid)
-        self.animal_rfid_list.append(clean_rfid)
 
     def simulate_all_rfid(self):
         '''Simulates RFID for all remaining unmapped animals.'''
@@ -344,8 +375,12 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 return
 
             while current_count < total_needed:
+                previous_count = current_count
                 self.add_random_rfid()
                 current_count = len(self.db.get_animals())
+                if current_count == previous_count:
+                    self.raise_warning("Unable to map remaining animals. Check group capacity and serial setup.")
+                    break
                 # Force UI update
                 self.update()
                 self.scroll_to_latest_entry()
@@ -375,25 +410,10 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
         # Generate a unique RFID
         rfid = get_random_rfid()
-        while str(rfid) in [str(animal[1]) for animal in self.animals]:  # Ensure unique RFID
+        while str(rfid) in [str(existing) for existing in self.animal_rfid_list]:
             rfid = get_random_rfid()
 
-        # Get the next animal ID
-        animal_id = self.get_next_animal()
-
-        # Find next available group
-        group_id = self.db.find_next_available_group()
-
-        # Add to database
-        self.db.add_animal(animal_id, rfid, group_id, '')
-        self.db._conn.commit()
-
-        # Add to UI table
-        self.table.insert('', END, values=(animal_id, rfid), tags='text_font')
-        self.animals.append((animal_id, rfid))
-
-        # Update entry text
-        self.change_entry_text()
+        self._add_rfid_mapping(rfid, play_audio=False)
 
 
     def add_value(self, rfid):
@@ -407,24 +427,9 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             self.raise_warning()
             return
 
-        # Get the next animal ID
-        animal_id = self.get_next_animal()
-
-        # Find next available group
-        group_id = self.db.find_next_available_group()
-
-        # Add to database
-        self.db.add_animal(animal_id, rfid, group_id, '')
-        self.db._conn.commit()
-
-        # Add to UI table
-        self.table.insert('', END, values=(animal_id, rfid), tags='text_font')
-        self.animals.append((animal_id, rfid))
-
-        AudioManager.play(SUCCESS_SOUND)
-
-        # Update entry text
-        self.change_entry_text()
+        added = self._add_rfid_mapping(rfid, play_audio=True)
+        if not added:
+            return
 
         total_scanned = len(self.db.get_animals())
         total_expected = self.db.get_total_number_animals()
@@ -436,20 +441,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         # If we haven't scanned all animals yet, restart serial listening.
         # HID fallback stays active and keeps listening without restart.
         if total_scanned < total_expected:
-            if self.use_hid_fallback:
-                print("⌨️ HID fallback active. Continuing to wait for next tag...")
-                FlashOverlay(
-                    parent=self,
-                    message="Scan Successful!",
-                    duration=1000,
-                    bg_color="#00FF00", #Bright Green
-                    text_color="black"
-                )
-                return
-
-            print("🔄 Restarting RFID listening...")
-            self.change_entry_text()
-            self.save()
+            print("⌨️ Waiting for next tag...")
             FlashOverlay(
                 parent=self,
                 message="Scan Successful!",
@@ -457,7 +449,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 bg_color="#00FF00", #Bright Green
                 text_color="black"
             )
-            self.rfid_listen()
+            return
         else:
             print("🎉 All animals have been mapped to RFIDs! RFID scanning completed.")
             print("RFIDs scanned: ", self.db.get_all_animals_rfid())
@@ -469,19 +461,40 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 bg_color="#FFF700", #Yellow to indicate completion
                 text_color="black"
             )
-            self.stop_listening()
+
+    def _add_rfid_mapping(self, rfid, play_audio=True):
+        """Insert RFID mapping into database and table. Returns True on success."""
+        animal_id = self.get_next_animal()
+        group_id = self.db.find_next_available_group()
+        if group_id is None:
+            self.raise_warning("No available group slot. Check group capacity.")
+            return False
+
+        inserted_id = self.db.add_animal(animal_id, rfid, group_id, '')
+        if inserted_id is None:
+            self.raise_warning("Failed to map RFID. Please try again.")
+            return False
+
+        self.db._conn.commit()
+        self.table.insert('', END, values=(animal_id, rfid), tags='text_font')
+        self.animals.append((animal_id, rfid))
+        if rfid not in self.animal_rfid_list:
+            self.animal_rfid_list.append(rfid)
+        self.change_entry_text()
+        self.scroll_to_latest_entry()
+
+        if play_audio:
+            AudioManager.play(SUCCESS_SOUND)
+        return True
 
     def item_selected(self, _):
         selected = self.table.selection()
         print("Selection ", selected, " changed.")
 
-        # Check if any selected item starts with 'I00'
-        enable_button = any(self.table.item(item_id, 'values')[0].startswith('I00') for item_id in selected)
-
-        if enable_button:
-            self.delete_button["state"] = "normal"
-        else:
-            self.delete_button["state"] = "disabled"
+        enable_button = len(selected) > 0
+        state = "normal" if enable_button else "disabled"
+        self.delete_button.configure(state=state)
+        self.sacrifice_button.configure(state=state)
 
     def remove_selected_items(self):
         '''Removes the selected item from a table, warning if none selected.'''
@@ -498,7 +511,9 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             self.table.selection_remove(item)
             self.table.delete(item)
             self.db.remove_animal(item_id)
-            self.animal_rfid_list.remove(rfid_value)
+            self.animals = [(index, tag) for (index, tag) in self.animals if index != item_id]
+            if rfid_value in self.animal_rfid_list:
+                self.animal_rfid_list.remove(rfid_value)
             print("Total number of animal rows in the table:", len(self.table.get_children()))
 
         self.save()
@@ -603,13 +618,11 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 # Close the database connection
                 self.db.close()  # This will now handle the singleton cleanup
 
-                self.stop_listening()
-
                 # Local import to avoid circular dependency
                 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 
                 # Create new ExperimentMenuUI instance with the same file
-                new_page = ExperimentMenuUI(self.parent, self.file_path, self.menu_page, self.file_path)
+                new_page = ExperimentMenuUI(self.parent, self.file_path, self.menu_page)
                 new_page.raise_frame()
 
             except Exception as e:
@@ -621,7 +634,6 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
     def raise_frame(self):
         '''Raise the frame for this UI'''
         super().raise_frame()
-        self.rfid_listen()
 
     def save(self):
         '''Saves current database state to permanent file'''
@@ -636,6 +648,11 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             # Save back to original file location
             print(f"Saving {current_file} to {self.file_path}")
             file_utils.save_temp_to_file(current_file, self.file_path)
+            try:
+                from ui.commands import save_file  # pylint: disable=import-outside-toplevel
+                save_file()
+            except Exception as save_exc:
+                print(f"Could not run global save_file() hook: {save_exc}")
             print("Save successful!")
 
         except Exception as e:
@@ -655,10 +672,13 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         # First mark the selected animals as inactive
         for item in selected_items:
             animal_id = int(self.table.item(item, 'values')[0])
+            rfid_value = self.table.item(item, 'values')[1]
             self.table.selection_remove(item)
             self.table.delete(item)
             self.db.set_animal_active_status(animal_id, 0)  # Mark as inactive
             self.animals = [(index, rfid) for (index, rfid) in self.animals if index != animal_id]
+            if rfid_value in self.animal_rfid_list:
+                self.animal_rfid_list.remove(rfid_value)
 
             # Then update the UI table
             self.change_entry_text()
@@ -675,6 +695,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
         # Lastly, commit and save changes (After all animals sacrificed)
         self.save()
+        self.change_entry_text()
 
 class SerialPortSelection():
     '''Serial port selection user interface.'''

--- a/shared/experiment.py
+++ b/shared/experiment.py
@@ -184,7 +184,7 @@ class Experiment():
 
     def set_measurement_type(self, is_automatic: int):
         '''Sets whether measurements are automatic (1) or manual (0).'''
-        self.measurement_type = is_automatic
+        self.data_collect_type = is_automatic
 
     def add_investigator(self, investigator_name):
         if investigator_name and investigator_name not in self.investigators:

--- a/shared/file_utils.py
+++ b/shared/file_utils.py
@@ -56,13 +56,6 @@ def save_temp_to_file(temp_file_path: str, permanent_file_path: str):
     temp_file_path = os.path.abspath(temp_file_path)
     permanent_file_path = os.path.abspath(permanent_file_path)
 
-    # Split the path into base and extension
-    base, ext = os.path.splitext(permanent_file_path)
-    # Take only the part before the first underscore if it exists
-    base = base.split('_')[0]
-
-    permanent_file_path = f"{base}{ext}"  # Updated line
-
     with open(temp_file_path, 'rb') as temp_file:
         data = temp_file.read()
 
@@ -74,12 +67,6 @@ def save_temp_to_encrypted(temp_file_path: str, permanent_file_path: str, passwo
     # Ensure paths are absolute and properly resolved
     temp_file_path = os.path.abspath(temp_file_path)
     permanent_file_path = os.path.abspath(permanent_file_path)
-
-    # Split the path into base and extension
-    base, ext = os.path.splitext(permanent_file_path)
-    # Take only the part before the first underscore if it exists
-    base = base.split('_')[0]
-    permanent_file_path = f"{base}{ext}"  # Updated line
 
     manager = PasswordManager(password)
 

--- a/shared/hid_wedge.py
+++ b/shared/hid_wedge.py
@@ -14,20 +14,28 @@ class HIDWedgeListener:
         widget,
         on_tag: Callable[[str], None],
         idle_reset_seconds: float = 1.5,
+        capture_all: bool = False,
     ):
         self.widget = widget
         self.on_tag = on_tag
         self.idle_reset_seconds = idle_reset_seconds
+        self.capture_all = capture_all
         self.buffer = []
         self.last_key_time = 0.0
         self._binding_id = None
         self._active = False
+        self._binding_target = widget
 
     def start(self):
         """Start listening for keypress events."""
         if self._active:
             return
-        self._binding_id = self.widget.bind("<KeyPress>", self._on_keypress, add="+")
+        if self.capture_all:
+            self._binding_target = self.widget.winfo_toplevel()
+            self._binding_id = self._binding_target.bind("<KeyPress>", self._on_keypress, add="+")
+        else:
+            self._binding_target = self.widget
+            self._binding_id = self._binding_target.bind("<KeyPress>", self._on_keypress, add="+")
         self._active = True
 
     def stop(self):
@@ -35,7 +43,7 @@ class HIDWedgeListener:
         if not self._active:
             return
         if self._binding_id:
-            self.widget.unbind("<KeyPress>", self._binding_id)
+            self._binding_target.unbind("<KeyPress>", self._binding_id)
         self._binding_id = None
         self._active = False
         self.buffer = []
@@ -43,14 +51,11 @@ class HIDWedgeListener:
     def _on_keypress(self, event):
         now = time.monotonic()
         if self.last_key_time and (now - self.last_key_time) > self.idle_reset_seconds:
-            self.buffer = []
+            self._flush_buffer()
         self.last_key_time = now
 
         if event.keysym in ("Return", "KP_Enter"):
-            value = "".join(self.buffer).strip()
-            self.buffer = []
-            if value:
-                self.on_tag(value)
+            self._flush_buffer()
             return
 
         if event.keysym == "BackSpace":
@@ -63,3 +68,10 @@ class HIDWedgeListener:
 
         if event.char and len(event.char) == 1 and event.char.isprintable():
             self.buffer.append(event.char)
+
+    def _flush_buffer(self):
+        """Emit current buffered tag (if present) and clear it."""
+        value = "".join(self.buffer).strip()
+        self.buffer = []
+        if value:
+            self.on_tag(value)


### PR DESCRIPTION
- [ ] Improved RFID scanning reliability in Map RFID by stabilizing serial-to-HID behavior, enabling robust HID keyboard-wedge capture, and ensured scans are processed consistently for real hardware input.
- [ ] Fixed Map RFID control behavior so scanning starts only on Start Scanning, stops only on Stop Listening, and row updates remain synchronized with successful DB operations for add/remove/sacrifice flows.
- [ ] Resolved data persistence issues by correcting temp-to-permanent save handling and ensuring mapped RFID data is preserved when experiments are closed and reopened via Open Experiment.
- [ ] Restored and completed Group Configuration wiring so existing measurement mode loads correctly and both group names and measurement type save properly in edit flow.
- [ ] Updated formatted CSV export so animal mapping data is always present, including animal_id and rfid, even when measurement rows are sparse.
- [ ] Included validation via compile checks and targeted tests to confirm stability of touched modules.