### PR TITLE
400 Inline edits

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -185,7 +185,6 @@ class DataCollectionUI(MouserPage):
         self.get_values_for_date()
 
         self.table.bind('<<TreeviewSelect>>', self.item_selected)
-        self.table.bind("<Double-1>", self._open_selected_for_edit)
         self.table.bind("<1>", self._on_table_click)
         
         # Initialize inline editor tracking
@@ -213,6 +212,9 @@ class DataCollectionUI(MouserPage):
 
     def _on_table_click(self, event):
         """Handle click for inline edit on None values."""
+        if self.database.get_measurement_type() != 0:
+            return
+        
         region = self.table.identify("region", event.x, event.y)
         if region == "cell":
             column_id = self.table.identify_column(event.x)
@@ -279,17 +281,6 @@ class DataCollectionUI(MouserPage):
         entry.bind("<FocusOut>", cleanup_editor)
         
         entry.focus_set()
-
-    def _open_selected_for_edit(self, _):
-        """Open the edit dialog for the currently selected row."""
-        selected = self.table.selection()
-        if selected:
-            self.changing_value = selected[0]
-            val = self.table.item(self.changing_value, "values")
-            if len(val) > 1 and str(val[1]) == 'None':
-                # Rely on single-click to open inline editor
-                return
-            self.open_changer()
 
     def set_status(self, text):
         """Update collection status line."""

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -187,6 +187,9 @@ class DataCollectionUI(MouserPage):
         self.table.bind('<<TreeviewSelect>>', self.item_selected)
         self.table.bind("<Double-1>", self._open_selected_for_edit)
         self.table.bind("<1>", self._on_table_click)
+        
+        # Initialize inline editor tracking
+        self._inline_editor = None
 
         self.changer = ChangeMeasurementsDialog(parent, self, self.measurement_strings)
 
@@ -217,12 +220,17 @@ class DataCollectionUI(MouserPage):
             if column_id == '#2':
                 val = self.table.item(row_id, "values")
                 if len(val) > 1 and str(val[1]) == 'None':
-                    self.table.selection_set(row_id)
+                    # Set selection and changing_value without triggering inline edit multiple times
                     self.changing_value = row_id
-                    self._enter_inline_edit(row_id, column_id)
+                    # Use after_idle to ensure table updates complete before opening inline edit
+                    self.table.after_idle(lambda: self._enter_inline_edit(row_id, column_id))
                     return "break"
 
     def _enter_inline_edit(self, row_id, column_id):
+        # Prevent multiple inline editors from opening
+        if hasattr(self, '_inline_editor') and self._inline_editor and self._inline_editor.winfo_exists():
+            return
+            
         # Get bounding box of the cell
         bbox = self.table.bbox(row_id, column_id)
         if not bbox:
@@ -232,12 +240,13 @@ class DataCollectionUI(MouserPage):
         # Define entry widget
         entry = CTkEntry(self.table, width=width, height=height, font=("Arial", self._ui.get("table_font_size", 14)))
         entry.place(x=x, y=y)
+        self._inline_editor = entry
 
         # Function to save when user presses Enter
         def save_edit(event=None):
             new_val = entry.get()
             if new_val.strip() == "":
-                entry.destroy()
+                cleanup_editor()
                 return
 
             try:
@@ -245,20 +254,29 @@ class DataCollectionUI(MouserPage):
                 _ = float(new_val)
             except ValueError:
                 self.raise_warning("Invalid input. Please enter a valid number.")
-                entry.destroy()
+                cleanup_editor()
                 return
 
             # Save the value
             animal_id = self.table.item(row_id, "values")[0]
+            
+            # Clean up editor first to prevent visual issues
+            cleanup_editor()
+            
+            # Then update the value (which will update both DB and table display)
             self.change_selected_value(animal_id, [new_val])
-            entry.destroy()
 
-        def on_focus_out(event):
-            entry.destroy()
+        def cleanup_editor(event=None):
+            if hasattr(self, '_inline_editor') and self._inline_editor:
+                try:
+                    self._inline_editor.destroy()
+                except:
+                    pass
+                self._inline_editor = None
 
         entry.bind("<Return>", save_edit)
-        entry.bind("<Escape>", on_focus_out)
-        entry.bind("<FocusOut>", on_focus_out)
+        entry.bind("<Escape>", cleanup_editor)
+        entry.bind("<FocusOut>", cleanup_editor)
         
         entry.focus_set()
 
@@ -532,10 +550,20 @@ class DataCollectionUI(MouserPage):
 
             # Update display table
             try:
+                updated = False
                 for child in self.table.get_children():
-                    if animal_id_to_change == self.table.item(child)["values"][0]:
+                    table_animal_id = self.table.item(child)["values"][0]
+                    # Handle type conversions for comparison
+                    if str(animal_id_to_change) == str(table_animal_id):
                         self.table.item(child, values=(animal_id_to_change, new_value))
-                print("Table display updated")
+                        updated = True
+                        # Force table to refresh/redraw
+                        self.table.update_idletasks()
+                        break
+                if updated:
+                    print(f"Table display updated for animal {animal_id_to_change}")
+                else:
+                    print(f"Warning: Could not find animal {animal_id_to_change} in table")
             except Exception as table_error:
                 print(f"Error updating table display: {table_error}")
 

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -212,9 +212,17 @@ class DataCollectionUI(MouserPage):
             self.changing_value = selected[0]
 
     def _on_table_click(self, event):
-        """Handle click for inline edit on None values."""
+        """Handle click for inline edit in manual mode (no popups)."""
         if self.database.get_measurement_type() != 0:
             return
+
+        # If an editor is already open, don't try to open another one.
+        if getattr(self, "_inline_editor", None) is not None:
+            try:
+                if self._inline_editor.winfo_exists():
+                    return "break"
+            except Exception:
+                pass
         
         region = self.table.identify("region", event.x, event.y)
         if region == "cell":
@@ -232,13 +240,12 @@ class DataCollectionUI(MouserPage):
             if column_index <= 0 or column_index >= len(values):
                 return
 
-            cell_value = values[column_index]
-            if cell_value is None or str(cell_value).strip() in ("", "None"):
-                # Keep selection behavior, but replace popup flow with inline edit.
-                self.table.selection_set(row_id)
-                self.changing_value = row_id
-                self._enter_inline_edit(row_id, column_id)
-                return "break"
+            # Keep selection behavior, but replace any popup flow with inline edit.
+            # Allow editing existing values too (not only None).
+            self.table.selection_set(row_id)
+            self.changing_value = row_id
+            self._enter_inline_edit(row_id, column_id)
+            return "break"
 
     def _enter_inline_edit(self, row_id, column_id):
         # Prevent multiple inline editors from opening
@@ -268,7 +275,22 @@ class DataCollectionUI(MouserPage):
             foreground=foreground,
             insertbackground=foreground,
         )
+        # Pre-fill with the current cell value (blank if None).
+        existing_values = self.table.item(row_id, "values") or ()
+        try:
+            column_index = int(str(column_id).lstrip("#")) - 1
+        except ValueError:
+            column_index = -1
+
+        initial_text = ""
+        if 0 <= column_index < len(existing_values):
+            cell_value = existing_values[column_index]
+            if cell_value is not None and str(cell_value).strip() not in ("", "None"):
+                initial_text = str(cell_value)
+
         entry.place(x=x, y=y, width=width, height=height)
+        if initial_text:
+            entry.insert(0, initial_text)
         self._inline_editor = entry
 
         # Function to save when user presses Enter
@@ -293,7 +315,8 @@ class DataCollectionUI(MouserPage):
             cleanup_editor()
             
             # Then update the value (which will update both DB and table display)
-            self.change_selected_value(animal_id, [new_val])
+            if self.change_selected_value(animal_id, [new_val]):
+                AudioManager.play(SUCCESS_SOUND)
 
         def cleanup_editor(event=None):
             if hasattr(self, '_inline_editor') and self._inline_editor:
@@ -308,6 +331,10 @@ class DataCollectionUI(MouserPage):
         entry.bind("<FocusOut>", cleanup_editor)
         
         entry.focus_set()
+        try:
+            entry.selection_range(0, "end")
+        except Exception:
+            pass
 
     def set_status(self, text):
         """Update collection status line."""
@@ -620,11 +647,13 @@ class DataCollectionUI(MouserPage):
                     print(f"Error type: {type(save_error)}")
                     import traceback
                     print(f"Full traceback: {traceback.format_exc()}")
+            return True
         except Exception as e:
             self.raise_warning("Failed to save data for animal.")
             print(f"Top level error: {e}")
             import traceback
             print(f"Full traceback: {traceback.format_exc()}")
+            return False
 
     def get_values_for_date(self):
         '''Gets the data for the current date as a string in YYYY-MM-DD.'''

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -186,6 +186,7 @@ class DataCollectionUI(MouserPage):
 
         self.table.bind('<<TreeviewSelect>>', self.item_selected)
         self.table.bind("<Double-1>", self._open_selected_for_edit)
+        self.table.bind("<1>", self._on_table_click)
 
         self.changer = ChangeMeasurementsDialog(parent, self, self.measurement_strings)
 
@@ -207,11 +208,69 @@ class DataCollectionUI(MouserPage):
         if selected:
             self.changing_value = selected[0]
 
+    def _on_table_click(self, event):
+        """Handle click for inline edit on None values."""
+        region = self.table.identify("region", event.x, event.y)
+        if region == "cell":
+            column_id = self.table.identify_column(event.x)
+            row_id = self.table.identify_row(event.y)
+            if column_id == '#2':
+                val = self.table.item(row_id, "values")
+                if len(val) > 1 and str(val[1]) == 'None':
+                    self.table.selection_set(row_id)
+                    self.changing_value = row_id
+                    self._enter_inline_edit(row_id, column_id)
+                    return "break"
+
+    def _enter_inline_edit(self, row_id, column_id):
+        # Get bounding box of the cell
+        bbox = self.table.bbox(row_id, column_id)
+        if not bbox:
+            return
+        x, y, width, height = bbox
+
+        # Define entry widget
+        entry = CTkEntry(self.table, width=width, height=height, font=("Arial", self._ui.get("table_font_size", 14)))
+        entry.place(x=x, y=y)
+
+        # Function to save when user presses Enter
+        def save_edit(event=None):
+            new_val = entry.get()
+            if new_val.strip() == "":
+                entry.destroy()
+                return
+
+            try:
+                # Ensure it is a valid float as expected
+                _ = float(new_val)
+            except ValueError:
+                self.raise_warning("Invalid input. Please enter a valid number.")
+                entry.destroy()
+                return
+
+            # Save the value
+            animal_id = self.table.item(row_id, "values")[0]
+            self.change_selected_value(animal_id, [new_val])
+            entry.destroy()
+
+        def on_focus_out(event):
+            entry.destroy()
+
+        entry.bind("<Return>", save_edit)
+        entry.bind("<Escape>", on_focus_out)
+        entry.bind("<FocusOut>", on_focus_out)
+        
+        entry.focus_set()
+
     def _open_selected_for_edit(self, _):
         """Open the edit dialog for the currently selected row."""
         selected = self.table.selection()
         if selected:
             self.changing_value = selected[0]
+            val = self.table.item(self.changing_value, "values")
+            if len(val) > 1 and str(val[1]) == 'None':
+                # Rely on single-click to open inline editor
+                return
             self.open_changer()
 
     def set_status(self, text):

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -1,6 +1,7 @@
 '''Data collection ui module.'''
 from datetime import date
 import re
+import tkinter as tk
 from tkinter.ttk import Treeview, Style
 import time
 from customtkinter import *
@@ -219,14 +220,25 @@ class DataCollectionUI(MouserPage):
         if region == "cell":
             column_id = self.table.identify_column(event.x)
             row_id = self.table.identify_row(event.y)
-            if column_id == '#2':
-                val = self.table.item(row_id, "values")
-                if len(val) > 1 and str(val[1]) == 'None':
-                    # Set selection and changing_value without triggering inline edit multiple times
-                    self.changing_value = row_id
-                    # Use after_idle to ensure table updates complete before opening inline edit
-                    self.table.after_idle(lambda: self._enter_inline_edit(row_id, column_id))
-                    return "break"
+            if not row_id or column_id == "#1":
+                return
+
+            values = self.table.item(row_id, "values") or ()
+            try:
+                column_index = int(str(column_id).lstrip("#")) - 1
+            except ValueError:
+                return
+
+            if column_index <= 0 or column_index >= len(values):
+                return
+
+            cell_value = values[column_index]
+            if cell_value is None or str(cell_value).strip() in ("", "None"):
+                # Keep selection behavior, but replace popup flow with inline edit.
+                self.table.selection_set(row_id)
+                self.changing_value = row_id
+                self._enter_inline_edit(row_id, column_id)
+                return "break"
 
     def _enter_inline_edit(self, row_id, column_id):
         # Prevent multiple inline editors from opening
@@ -239,9 +251,24 @@ class DataCollectionUI(MouserPage):
             return
         x, y, width, height = bbox
 
-        # Define entry widget
-        entry = CTkEntry(self.table, width=width, height=height, font=("Arial", self._ui.get("table_font_size", 14)))
-        entry.place(x=x, y=y)
+        # Use a lightweight native tkinter Entry for fast, truly-inline editing (no popup).
+        # CTkEntry can look like a separate "box" overlay; a flat Entry blends into the cell.
+        style = Style()
+        background = style.lookup("DataCollection.Treeview", "fieldbackground") or style.lookup("Treeview", "fieldbackground") or "white"
+        foreground = style.lookup("DataCollection.Treeview", "foreground") or style.lookup("Treeview", "foreground") or "black"
+
+        entry = tk.Entry(
+            self.table,
+            bd=0,
+            highlightthickness=0,
+            relief="flat",
+            justify="center",
+            font=("Arial", self._ui.get("table_font_size", 14)),
+            background=background,
+            foreground=foreground,
+            insertbackground=foreground,
+        )
+        entry.place(x=x, y=y, width=width, height=height)
         self._inline_editor = entry
 
         # Function to save when user presses Enter

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ cryptography
 customtkinter
 CTkMessagebox
 CTkMenuBar
-git+https://github.com/taconi/playsound.git
+playsound==1.2.2
 requests


### PR DESCRIPTION
Fixes #400 

**What was changed?**
The Data Collection page table has been updated. Specifically, the way users interact with empty (None) cells in the Treeview has been modified. A new inline editing component (CTkEntry) is now overlaid directly onto the table cell, replacing the need to launch the ChangeMeasurementsDialog popup for empty values.

**Why was it changed?**
This change addresses a workflow interruption during manual data collection. Previously, clicking on a None value to input data would open a separate window/popup, which was slow and disruptive to the data entry flow. By allowing inline editing, the interface becomes much faster and more responsive, allowing researchers to quickly input data down the list without navigating through extra windows.

**How was it changed?**
Modified data_collection_ui.py. 
Added a single-click event bindingto detect exactly which cell the user clicks using self.table.identify(...).
Implemented _enter_inline_edit(self, row_id, column_id) which calculates the screen coordinates of the target cell using self.table.bbox() and instantly places a CTkEntry widget perfectly over the cell.
Added event bindings to the temporary CTkEntry widget: <Return> validates the input and seamlessly pipes it into the pre-existing self.change_selected_value(...) database method. <Escape> and <FocusOut> safely destroy the widget without saving if the user cancels.
Updated _open_selected_for_edit (the existing double-click handler) with a guard clause to intentionally ignore/return early on None values, ensuring the old popup window is no longer created for empty data points.

