### PR TITLE
399 investigator page should display current investigators and update list immediately on add

### DIFF
--- a/experiment_pages/experiment/experiment_invest_ui.py
+++ b/experiment_pages/experiment/experiment_invest_ui.py
@@ -6,6 +6,7 @@ from customtkinter import (
     CTkButton,
     CTkEntry,
     CTkScrollableFrame,
+    CTkTextbox,
     CTkFont,
 )
 from tkinter import messagebox
@@ -20,7 +21,7 @@ class InvestigatorsUI(MouserPage):
         super().__init__(parent, "Investigators", prev_page)
         self.file_path = file_path
         self.db = ExperimentDatabase(file_path)
-        self.investigators = self.db.get_investigators()
+        self.investigators = []
 
         self.configure(fg_color=("white", "#18181b"))
         self.grid_rowconfigure((0, 1), weight=1)
@@ -53,7 +54,7 @@ class InvestigatorsUI(MouserPage):
             border_color="#d1d5db",
         )
         card.grid(row=1, column=0, padx=80, pady=20, sticky="nsew")
-        card.grid_rowconfigure(1, weight=1)
+        card.grid_rowconfigure(2, weight=1)
         card.grid_columnconfigure(0, weight=1)
 
         input_row = CTkFrame(card, fg_color="transparent")
@@ -73,12 +74,23 @@ class InvestigatorsUI(MouserPage):
             hover_color="#1e40af",
         ).grid(row=0, column=1)
 
-        self.list_frame = CTkScrollableFrame(card, fg_color=("white", "#1f2937"))
-        self.list_frame.grid(row=1, column=0, padx=25, pady=10, sticky="nsew")
+        CTkLabel(
+            card,
+            text="Current Investigators",
+            font=CTkFont("Segoe UI", 16, weight="bold"),
+            text_color=("#111827", "#e5e7eb"),
+        ).grid(row=1, column=0, padx=25, pady=(0, 4), sticky="w")
+
+        self.investigator_textbox = CTkTextbox(card, height=100, wrap="word")
+        self.investigator_textbox.grid(row=2, column=0, padx=25, pady=(0, 10), sticky="nsew")
+        self.investigator_textbox.configure(state="disabled")
+
+        self.list_frame = CTkScrollableFrame(card, fg_color=("white", "#1f2937"), height=170)
+        self.list_frame.grid(row=3, column=0, padx=25, pady=10, sticky="nsew")
         self.list_frame.grid_columnconfigure(0, weight=1)
 
         actions = CTkFrame(card, fg_color="transparent")
-        actions.grid(row=2, column=0, padx=25, pady=(10, 20), sticky="e")
+        actions.grid(row=4, column=0, padx=25, pady=(10, 20), sticky="e")
 
         CTkButton(
             actions,
@@ -98,9 +110,26 @@ class InvestigatorsUI(MouserPage):
             hover_color="#374151",
         ).grid(row=0, column=1)
 
+        self._load_investigators()
+
+    def _load_investigators(self):
+        self.investigators = self.db.get_investigators()
+        self._refresh_list()
+
+    def _persist_investigators(self):
+        self.db.update_investigators(self.investigators)
+        self.investigators = self.db.get_investigators()
         self._refresh_list()
 
     def _refresh_list(self):
+        self.investigator_textbox.configure(state="normal")
+        self.investigator_textbox.delete("1.0", "end")
+        if self.investigators:
+            self.investigator_textbox.insert("1.0", "\n".join(self.investigators))
+        else:
+            self.investigator_textbox.insert("1.0", "No investigators added yet.")
+        self.investigator_textbox.configure(state="disabled")
+
         for widget in self.list_frame.winfo_children():
             widget.destroy()
 
@@ -136,15 +165,15 @@ class InvestigatorsUI(MouserPage):
             return
         self.investigators.append(name)
         self.input_entry.delete(0, "end")
-        self._refresh_list()
+        self._persist_investigators()
 
     def remove_investigator(self, name):
         if name in self.investigators:
             self.investigators.remove(name)
-            self._refresh_list()
+            self._persist_investigators()
 
     def save_investigators(self):
-        self.db.update_investigators(self.investigators)
+        self._persist_investigators()
         messagebox.showinfo("Saved", "Investigators updated successfully.")
 
     def go_back(self):
@@ -152,3 +181,7 @@ class InvestigatorsUI(MouserPage):
             prev = getattr(self.menu_button, "previous_page", None)
             if prev is not None and hasattr(prev, "raise_frame"):
                 prev.raise_frame()
+
+    def raise_frame(self):
+        self._load_investigators()
+        super().raise_frame()

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from shared.serial_port_controller import SerialPortController  # pylint: disabl
 from ui.root_window import create_root_window  # pylint: disable=wrong-import-position
 from ui.menu_bar import build_menu  # pylint: disable=wrong-import-position
 from ui.welcome_screen import setup_welcome_screen  # pylint: disable=wrong-import-position
+from ui.commands import save_and_close  # pylint: disable=wrong-import-position
 
 
 # Global app variables
@@ -67,6 +68,7 @@ build_menu(
     experiments_frame=experiments_frame,
     rfid_serial_port_controller=rfid_serial_port_controller,
 )
+root.protocol("WM_DELETE_WINDOW", lambda: save_and_close(root))
 
 # Final grid configuration
 raise_frame(experiments_frame)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ customtkinter
 CTkMessagebox
 CTkMenuBar
 # git+https://github.com/taconi/playsound.git
+Pillow==12.0.0
 requests

--- a/tests/test_investigators_ui.py
+++ b/tests/test_investigators_ui.py
@@ -1,0 +1,125 @@
+"""Tests for Investigator page display and add behavior."""
+
+import os
+import sys
+
+import pytest
+from customtkinter import CTk
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from databases.experiment_database import ExperimentDatabase
+from experiment_pages.experiment.experiment_invest_ui import InvestigatorsUI
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database_instances():
+    """Reset DB singletons for test isolation."""
+    ExperimentDatabase._instances.clear()  # pylint: disable=protected-access
+    yield
+    for db in list(ExperimentDatabase._instances.values()):  # pylint: disable=protected-access
+        db.close()
+    ExperimentDatabase._instances.clear()  # pylint: disable=protected-access
+
+
+@pytest.fixture(scope="module")
+def tk_root():
+    """Create one Tk root for all tests, skip suite if Tk is unavailable."""
+    try:
+        root = CTk()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        pytest.skip(f"Tk unavailable for UI tests: {exc}")
+    root.withdraw()
+    yield root
+    root.destroy()
+
+
+def _displayed_investigators(page: InvestigatorsUI) -> list[str]:
+    names: list[str] = []
+    for row in page.list_frame.winfo_children():
+        text = None
+        if hasattr(row, "cget"):
+            try:
+                text = row.cget("text")
+            except ValueError:
+                text = None
+        if text and text != "No investigators added yet.":
+            names.append(text)
+            continue
+
+        for child in row.winfo_children():
+            if not hasattr(child, "cget"):
+                continue
+            child_text = child.cget("text")
+            if child_text and child_text != "Remove":
+                names.append(child_text)
+    return names
+
+
+def _textbox_investigators(page: InvestigatorsUI) -> list[str]:
+    return [
+        line.strip()
+        for line in page.investigator_textbox.get("1.0", "end-1c").splitlines()
+        if line.strip() and line.strip() != "No investigators added yet."
+    ]
+
+
+def test_investigator_page_loads_existing_investigators(tmp_path, tk_root):
+    """Page load should render currently persisted investigators."""
+    db_path = tmp_path / "investigator_load.db"
+    db = ExperimentDatabase(str(db_path))
+    db.setup_experiment(
+        "Load Test",
+        "Mouse",
+        False,
+        2,
+        1,
+        2,
+        0,
+        "load-test",
+        ["Dr. Smith", "Dr. Jones"],
+        "Weight",
+    )
+
+    page = None
+    try:
+        page = InvestigatorsUI(tk_root, None, str(db_path))
+        tk_root.update_idletasks()
+        assert _displayed_investigators(page) == ["Dr. Smith", "Dr. Jones"]
+        assert _textbox_investigators(page) == ["Dr. Smith", "Dr. Jones"]
+    finally:
+        if page is not None:
+            page.destroy()
+
+
+def test_add_investigator_updates_ui_and_persists_without_refresh(tmp_path, tk_root):
+    """Add action should update in-memory UI list and backing storage immediately."""
+    db_path = tmp_path / "investigator_add.db"
+    db = ExperimentDatabase(str(db_path))
+    db.setup_experiment(
+        "Add Test",
+        "Mouse",
+        False,
+        2,
+        1,
+        2,
+        0,
+        "add-test",
+        ["Dr. Smith"],
+        "Weight",
+    )
+
+    page = None
+    try:
+        page = InvestigatorsUI(tk_root, None, str(db_path))
+        page.input_entry.insert(0, "Dr. Brown")
+        page.add_investigator()
+        tk_root.update_idletasks()
+
+        assert _displayed_investigators(page) == ["Dr. Smith", "Dr. Brown"]
+        assert _textbox_investigators(page) == ["Dr. Smith", "Dr. Brown"]
+        assert page.db.get_investigators() == ["Dr. Smith", "Dr. Brown"]
+    finally:
+        if page is not None:
+            page.destroy()

--- a/tests/test_save_on_exit.py
+++ b/tests/test_save_on_exit.py
@@ -1,0 +1,85 @@
+"""Tests for application save behavior on exit."""
+
+import os
+import sys
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from databases.experiment_database import ExperimentDatabase
+from shared import file_utils
+from ui.commands import global_state, save_and_close
+
+
+class DummyRoot:
+    """Minimal root-like object for close callback tests."""
+
+    def __init__(self):
+        self.destroy_called = False
+
+    def destroy(self):
+        self.destroy_called = True
+
+
+@pytest.fixture(autouse=True)
+def cleanup_state():
+    """Reset singleton DB instances and command global state."""
+    prior_state = global_state.copy()
+    ExperimentDatabase._instances.clear()  # pylint: disable=protected-access
+    yield
+    for db in list(ExperimentDatabase._instances.values()):  # pylint: disable=protected-access
+        db.close()
+    ExperimentDatabase._instances.clear()  # pylint: disable=protected-access
+    global_state.clear()
+    global_state.update(prior_state)
+
+
+def test_save_and_close_persists_temp_changes_to_original(tmp_path):
+    """Closing app should copy temp DB updates back to original file."""
+    original_path = tmp_path / "experiment.mouser"
+
+    db = ExperimentDatabase(str(original_path))
+    db.setup_experiment(
+        "Exit Save",
+        "Mouse",
+        False,
+        4,
+        1,
+        4,
+        0,
+        "exit-save-id",
+        ["Dr. A"],
+        "Weight",
+    )
+    db.close()
+
+    temp_path = file_utils.create_temp_copy(str(original_path))
+    temp_db = ExperimentDatabase(temp_path)
+    temp_db.update_investigators(["Dr. A", "Dr. B"])
+
+    global_state["current_file_path"] = str(original_path)
+    global_state["temp_file_path"] = temp_path
+    global_state["password"] = None
+
+    root = DummyRoot()
+    save_and_close(root)
+
+    assert root.destroy_called
+
+    saved_db = ExperimentDatabase(str(original_path))
+    assert saved_db.get_investigators() == ["Dr. A", "Dr. B"]
+    saved_db.close()
+
+
+def test_save_and_close_without_active_file_still_closes():
+    """Closing app should still close root when no file is active."""
+    global_state["current_file_path"] = None
+    global_state["temp_file_path"] = None
+    global_state["password"] = None
+
+    root = DummyRoot()
+    save_and_close(root)
+
+    assert root.destroy_called

--- a/ui/commands.py
+++ b/ui/commands.py
@@ -137,3 +137,14 @@ def save_file():
         file_utils.save_temp_to_file(temp_file, current_file)
     else:
         print("Save skipped — missing file path.")
+
+
+def save_and_close(root):
+    """Persist current experiment data, then close the application window."""
+    from databases.experiment_database import ExperimentDatabase  # pylint: disable=import-outside-toplevel
+
+    for db in list(ExperimentDatabase._instances.values()):  # pylint: disable=protected-access
+        db.close()
+
+    save_file()
+    root.destroy()


### PR DESCRIPTION
Closes #399

 ## Summary

 **What changed?**
 - Updated the Investigator page to load and display existing investigators on page
load and when the page is reopened.
 - Added a visible **Current Investigators** textbox and kept the scrollable
remove-list in sync.
 - Made **Add** and **Remove** persist immediately to the experiment DB and refresh the
 UI right away (no page refresh needed).
 - Added app close-save handling so closing the window (X) saves temp experiment
changes to the original file.
 - Added regression tests:
   - `tests/test_investigators_ui.py`
   - `tests/test_save_on_exit.py`

 **Why?**
 - Existing investigators were not reliably visible when opening the Investigator page.
 - Investigator updates could be lost when exiting via window close because changes
were not always saved back to the original experiment file.

 ## How to test
 - Open an existing experiment that already has investigators.
 - Go to **Investigators** and confirm current investigators are visible immediately.
 - Add a new investigator and confirm it appears instantly on the same page.
 - Close the app via the window close button (X), reopen the same experiment, and
verify the added investigator persists.
 - Optionally remove an investigator and repeat close/reopen to confirm persistence.
 - Run: `pytest -q tests\test_investigators_ui.py tests\test_save_on_exit.py`