### PR TITLE
Fixed the issue with the data collection page.

### DIFF
--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -42,6 +42,8 @@ class DataCollectionUI(MouserPage):
 
         self.database = ExperimentDatabase(database_name)
 
+        # Database stores a single measurement name in `experiment.measurement`.
+        # Older code paths may return tuples from fetchone(); normalize to a string.
         self.measurement_items = self.database.get_measurement_items()
         self.menu_button.configure(command = self.press_back_to_menu_button)
         self.export_notification = CTkLabel(
@@ -98,9 +100,11 @@ class DataCollectionUI(MouserPage):
         #     animal_ids = [animal[0] for animal in self.database.get_animals()]  # Get all animal IDs
         #     self.database.insert_blank_data_for_day(animal_ids, today_date)  # Insert blank dataS
 
-        self.measurement_strings = self.measurement_items  # already a list
-        columns.extend(self.measurement_strings)  # adds each measurement as separate column
-        print(self.measurement_items)
+        measurement_name = self.database.get_measurement_name()
+        if isinstance(measurement_name, (list, tuple)):
+            measurement_name = measurement_name[0] if measurement_name else None
+        self.measurement_strings = [measurement_name] if measurement_name else []
+        print("Measurement(s):", self.measurement_strings)
 
         if self.database.experiment_uses_rfid() == 0:
             start_function = self.auto_increment
@@ -152,9 +156,7 @@ class DataCollectionUI(MouserPage):
 
 
 
-        columns = ['animal_id']
-        print(self.database.get_measurement_name())
-        columns.append(str(self.database.get_measurement_name())) # Add measurement name as column
+        columns = ["animal_id", *self.measurement_strings]
 
         # Initialize the Treeview with the defined columns
         self.table = Treeview(self.table_frame,

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -220,12 +220,23 @@ class ExperimentMenuUI(MouserPage):
 
     def open_data_collection(self):
         """Open Data Collection Page."""
+        if self.experiment_db.experiment_uses_rfid() == 1 and not self.all_rfid_mapped():
+            messagebox.showinfo(
+                "RFID Mapping Required",
+                "This experiment uses RFID.\n\n"
+                "Map RFID for all animals before starting Data Collection.",
+            )
+            return
+
         from experiment_pages.experiment.data_collection_ui import (  # pylint: disable=import-error,import-outside-toplevel
             DataCollectionUI,
         )
 
-        page = DataCollectionUI(self.root, self, self.file_path, self.file_path)
-        page.raise_frame()
+        try:
+            page = DataCollectionUI(self.root, self, self.file_path, self.file_path)
+            page.raise_frame()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            messagebox.showerror("Data Collection Error", f"Failed to open Data Collection page.\n\n{e}")
 
     def open_data_analysis(self):
         """Open Data Analysis Page."""
@@ -276,13 +287,19 @@ class ExperimentMenuUI(MouserPage):
             if not self.all_rfid_mapped():
                 self.collection_button.configure(state="disabled")
                 self.analysis_button.configure(state="disabled")
+                self.collection_button.configure(text="Data Collection")
+                self.analysis_button.configure(text="Data Analysis")
             else:
                 self.collection_button.configure(state="normal")
                 self.analysis_button.configure(state="normal")
+                self.collection_button.configure(text="Data Collection")
+                self.analysis_button.configure(text="Data Analysis")
             self.rfid_button.configure(state="normal")
         else:
             self.collection_button.configure(state="normal")
             self.analysis_button.configure(state="normal")
+            self.collection_button.configure(text="Data Collection")
+            self.analysis_button.configure(text="Data Analysis")
             self.rfid_button.configure(state="disabled")
 
     def disconnect_database(self):


### PR DESCRIPTION
This PR fixes an issue where the Data Collection page could not be opened from the Experiment Menu: data_collection_ui.py was using columns before it was defined, causing the page to crash during initialization and making the button appear to do nothing. The PR also improves the RFID gating UX in experiment_menu_ui.py by clearly indicating when Data Collection/Data Analysis are blocked until RFID mapping is completed.