### PR TITLE
Map RFID: remove duplicate notification UX (modal popup + flash) and use overlay-only feedback

### DIFF
--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -785,7 +785,7 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
                 parent=self,
                 message="Scan successful! All RFIDs scanned.",
                 duration=4000,
-                bg_color="#FFF700", #Yellow to indicate completion
+                bg_color="#00FF00", # Green to keep success feedback consistent
                 text_color="black"
             )
 
@@ -880,21 +880,8 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.serial_port_panel.open()
 
     def raise_warning(self, warning_message = 'Maximum number of animals reached'):
-        '''Raises an error window.'''
-
-        message = CTk()
-        message.title("WARNING")
-        message.geometry('320x100')
-        message.resizable(False, False)
-
-        label = CTkLabel(message, text= warning_message)
-        label.grid(row=0, column=0, padx=10, pady=10)
-
-
-        ok_button = CTkButton(message, text="OK", width=10,
-                        command= lambda: [message.destroy()])
-        ok_button.grid(row=2, column=0, padx=10, pady=10)
-
+        '''Show warning as non-blocking overlay only (no modal dialog).'''
+        self.set_reader_status(str(warning_message))
         FlashOverlay(
             parent=self,
             message=warning_message,
@@ -903,8 +890,6 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
             text_color="black"
         )
         AudioManager.play(ERROR_SOUND)
-
-        message.mainloop()
 
     def update(self):
         """Updates the table view to match the database state."""

--- a/shared/flash_overlay.py
+++ b/shared/flash_overlay.py
@@ -10,6 +10,10 @@ class FlashOverlay:
 
         self.parent = parent
         self.duration = duration
+        self._z_job = None
+
+        # Suspend periodic nav-button lifting while overlay is visible.
+        self._set_overlay_nav_lock(+1)
 
         # Create flash overlay frame
         self.flash_frame = CTkFrame(parent, fg_color=bg_color)
@@ -23,16 +27,62 @@ class FlashOverlay:
             text_color=text_color
         )
         self.label.place(relx=0.5, rely=0.5, anchor=CENTER)
+        try:
+            self.flash_frame.lift()
+            self.label.lift()
+        except Exception:
+            pass
+
+        # Keep overlay above all page widgets (including nav buttons) for full duration.
+        self._keep_on_top()
 
         # Schedule the fade out
         self.parent.after(self.duration, self._fade_out)
+
+    def _set_overlay_nav_lock(self, delta: int):
+        """Reference-count overlay visibility to coordinate with page nav lifting."""
+        try:
+            count = int(getattr(self.parent, "_active_flash_overlays", 0) or 0)
+            count = max(0, count + int(delta))
+            setattr(self.parent, "_active_flash_overlays", count)
+            setattr(self.parent, "_nav_lift_suspended", bool(count > 0))
+        except Exception:
+            pass
+
+    def _keep_on_top(self):
+        """Continuously re-lift the overlay while active."""
+        if not self.flash_frame.winfo_exists():
+            return
+        try:
+            self.flash_frame.lift()
+            self.label.lift()
+        except Exception:
+            pass
+        try:
+            self._z_job = self.parent.after(20, self._keep_on_top)
+        except Exception:
+            self._z_job = None
 
     def _fade_out(self):
         '''Removes the flash overlay'''
         if self.flash_frame.winfo_exists():
             self.flash_frame.destroy()
+        if self._z_job is not None:
+            try:
+                self.parent.after_cancel(self._z_job)
+            except Exception:
+                pass
+            self._z_job = None
+        self._set_overlay_nav_lock(-1)
 
     def destroy(self):
         '''Manually destroy the overlay before the duration'''
         if self.flash_frame.winfo_exists():
             self.flash_frame.destroy()
+        if self._z_job is not None:
+            try:
+                self.parent.after_cancel(self._z_job)
+            except Exception:
+                pass
+            self._z_job = None
+        self._set_overlay_nav_lock(-1)

--- a/shared/tk_models.py
+++ b/shared/tk_models.py
@@ -177,6 +177,8 @@ class MouserPage(CTkFrame):
 
     def _lift_nav_widgets(self):
         """Keep navigation buttons clickable/visible above page content."""
+        if bool(getattr(self, "_nav_lift_suspended", False)):
+            return
         for widget in (self.menu_button, self.next_button, self.previous_button):
             if widget is None:
                 continue


### PR DESCRIPTION
**Summary**
This PR fixes the multi-notification issue on Map RFID where users could see both a popup dialog and a flash notification for the same scan event.

**Changes**

- [ ] Updated MapRFIDPage.raise_warning() to overlay-only (red flash + status + sound), removed modal window creation.
- [ ] Kept scan success notifications as green overlays.
- [ ] Standardized completion success overlay to green.
