### PR TITLE
Fix encrypted file save corrupting temp file and button responsiveness

### DIFF
--- a/databases/experiment_database.py
+++ b/databases/experiment_database.py
@@ -190,13 +190,9 @@ class ExperimentDatabase:
         return result
 
     def close(self):
-        '''Closes database connection and cleans up singleton instance.'''
+        '''Close the database connection and clean up the instance.'''
         try:
             if self._conn is not None:
-                # Commit any pending transactions
-                self._conn.commit()
-
-                # Close the cursor if it exists
                 if self._c is not None:
                     self._c.close()
                     self._c = None
@@ -204,6 +200,12 @@ class ExperimentDatabase:
                 # Close the connection
                 self._conn.close()
                 self._conn = None
+
+                # Remove from singleton instances to allow reconnection
+                file_path = getattr(self, 'db_file', None)
+                if file_path and file_path in ExperimentDatabase._instances:
+                    del ExperimentDatabase._instances[file_path]
+                    print(f"DEBUG: Removed {file_path} from _instances")
 
                 return True
         except sqlite3.Error as e:

--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -582,6 +582,7 @@ class CageConfigurationUI(MouserPage):
     def autosort(self):
         '''Calls database's autosort function after user confirmation.'''
         confirmed = messagebox.askyesno(
+            parent=self.parent,
             title="Confirm AutoSort",
             message="Are you sure you want to AutoSort?\nThis will remove measurements used to sort from the database.",
         )

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -1875,9 +1875,11 @@ class DataCollectionUI(MouserPage):
     def raise_warning(self, warning_message='An error occurred'):
         '''Raises a popup warning message.'''
         CTkMessagebox(
+            master=self.parent,
+            topmost=True,
             title="Warning",
             message=warning_message,
-            icon="warning"
+            icon="warning",
         )
         AudioManager.play(ERROR_SOUND)
 

--- a/experiment_pages/experiment/experiment_invest_ui.py
+++ b/experiment_pages/experiment/experiment_invest_ui.py
@@ -228,7 +228,7 @@ class InvestigatorsUI(MouserPage):
 
     def save_investigators(self):
         self.db.update_investigators(self.investigators)
-        messagebox.showinfo("Saved", "Investigators updated successfully.")
+        messagebox.showinfo(parent=self.parent, title="Saved", message="Investigators updated successfully.")
 
     def go_back(self):
         if hasattr(self, "menu_button") and self.menu_button:

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -163,9 +163,9 @@ class ExperimentMenuUI(MouserPage):
             from ui.commands import save_file  # pylint: disable=import-outside-toplevel
 
             save_file()
-        except Exception:  # pylint: disable=broad-exception-caught
-            # If we can't persist (e.g., tests or non-standard entry), keep local temp state only.
-            pass
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # Log the error so we can debug issues instead of silently failing.
+            print(f"Failed to persist temp to original: {e}")
 
     def _ensure_notebook_table(self):
         try:

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -159,11 +159,33 @@ class ExperimentMenuUI(MouserPage):
         any notes saved into the temp DB would be lost when the experiment is reopened.
         """
         try:
+            # Commit any pending changes before saving
+            if hasattr(self, 'experiment_db') and self.experiment_db:
+                try:
+                    self.experiment_db._conn.commit()  # pylint: disable=protected-access
+                    print("DEBUG: Committed pending changes before save")
+                except Exception as commit_e:
+                    print(f"DEBUG: Error committing before save: {commit_e}")
+
             # Import lazily to avoid circular imports (ui.commands imports this module).
             from ui.commands import save_file  # pylint: disable=import-outside-toplevel
 
             save_file()
-        except Exception:  # pylint: disable=broad-exception-caught
+
+            # Refresh the database connection after save to ensure it's still valid
+            try:
+                if hasattr(self, 'experiment_db') and self.experiment_db:
+                    self.experiment_db.close()
+                    self.experiment_db = ExperimentDatabase(self.file_path)
+                    print("DEBUG: Refreshed experiment_db after save")
+            except Exception as refresh_e:
+                print(f"DEBUG: Error refreshing DB after save: {refresh_e}")
+                # Don't fail the save if refresh fails - the temp DB might still be usable
+
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            print(f"DEBUG: Error in _persist_temp_to_original_if_available: {e}")
+            import traceback
+            traceback.print_exc()
             # If we can't persist (e.g., tests or non-standard entry), keep local temp state only.
             pass
 
@@ -800,6 +822,55 @@ class ExperimentMenuUI(MouserPage):
                 ExperimentDatabase,
             )
 
+            # Close existing connection and refresh to ensure valid DB
+            if hasattr(self, 'experiment_db') and self.experiment_db:
+                try:
+                    self.experiment_db.close()
+                except Exception:
+                    pass
+                self.experiment_db = None
+
+            # Recreate DB connection
+            self.experiment_db = ExperimentDatabase(self.file_path)
+
+            if self.experiment_db.get_number_groups() == 0:
+                messagebox.showinfo(
+                    parent=self.root,
+                    title="Groups Required",
+                    message="No groups are configured yet.\n\n"
+                    "Create groups in Group Configuration before assigning cages.",
+                )
+                self.open_group_config()
+                return
+
+            from experiment_pages.experiment.cage_config_ui import (  # pylint: disable=import-error,import-outside-toplevel
+                CageConfigUI,
+            )
+
+            page = CageConfigUI(self.file_path, self.root, self, self.file_path)
+            page.raise_frame()
+        except sqlite3.DatabaseError as exc:
+            messagebox.showerror(
+                parent=self.root,
+                title="Cage Configuration Error",
+                message="This experiment file could not be opened as a database.\n\n"
+                f"{exc}",
+            )
+            print(f"ERROR open_cage_config: {exc}")
+            import traceback
+            traceback.print_exc()
+            # Refresh the page to restore button functionality
+            self.disable_buttons_if_needed()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            messagebox.showerror(
+                parent=self.root,
+                title="Cage Configuration Error",
+                message=f"Failed to open Cage Configuration page.\n\n{exc}",
+            )
+            print(f"ERROR open_cage_config unexpected: {exc}")
+            import traceback
+            traceback.print_exc()
+
             db = ExperimentDatabase(self.file_path)
             if db.get_number_groups() == 0:
                 messagebox.showinfo(
@@ -873,12 +944,22 @@ class ExperimentMenuUI(MouserPage):
 
     def open_map_rfid(self):
         """Open Map RFID Page."""
-        from experiment_pages.experiment.map_rfid import (  # pylint: disable=import-error,import-outside-toplevel
-            MapRFIDPage,
-        )
-
-        page = MapRFIDPage(self.file_path, self.root, self, self.file_path)
-        page.raise_frame()
+        try:
+            from experiment_pages.experiment.map_rfid import (  # pylint: disable=import-error,import-outside-toplevel
+                MapRFIDPage,
+            )
+            page = MapRFIDPage(self.file_path, self.root, self, self.file_path)
+            page.raise_frame()
+        except Exception as e:
+            import traceback
+            error_msg = f"Failed to open Map RFID page:\n{e}"
+            try:
+                from CTkMessagebox import CTkMessagebox
+                CTkMessagebox(title="Error", message=error_msg, icon="cancel")
+            except ImportError:
+                pass
+            print(f"ERROR in open_map_rfid: {e}")
+            traceback.print_exc()
 
     def open_summary(self):
         """Open Experiment Summary Page."""
@@ -910,18 +991,25 @@ class ExperimentMenuUI(MouserPage):
             self.experiment_db = ExperimentDatabase(self.file_path)
         if hasattr(self, "group_tile"):
             self.group_tile.set_enabled(True)
-        if self.experiment_db.experiment_uses_rfid() == 1:
-            if not self.all_rfid_mapped():
+
+        uses_rfid = self.experiment_db.experiment_uses_rfid()
+        all_mapped = self.all_rfid_mapped() if uses_rfid == 1 else False
+        print(f"DEBUG disable_buttons_if_needed: uses_rfid={uses_rfid}, all_mapped={all_mapped}")
+
+        if uses_rfid == 1:
+            if not all_mapped:
                 self.collection_tile.set_enabled(False)
                 self.analysis_tile.set_enabled(False)
             else:
                 self.collection_tile.set_enabled(True)
                 self.analysis_tile.set_enabled(True)
             self.rfid_button.configure(state="normal")
+            print("DEBUG: RFID button ENABLED")
         else:
             self.collection_tile.set_enabled(True)
             self.analysis_tile.set_enabled(True)
             self.rfid_button.configure(state="disabled")
+            print("DEBUG: RFID button DISABLED (experiment_uses_rfid != 1)")
 
     def disconnect_database(self):
         """Close experiment DB connection if possible."""

--- a/experiment_pages/experiment/experiment_menu_ui.py
+++ b/experiment_pages/experiment/experiment_menu_ui.py
@@ -748,8 +748,9 @@ class ExperimentMenuUI(MouserPage):
             db = ExperimentDatabase(self.file_path)
         except sqlite3.DatabaseError:
             messagebox.showerror(
-                "Open Experiment Error",
-                "This experiment file could not be opened as a database.\n"
+                parent=self.root,
+                title="Open Experiment Error",
+                message="This experiment file could not be opened as a database.\n"
                 "If it is password protected, please use the appropriate "
                 "flow to unlock it.",
             )
@@ -802,8 +803,9 @@ class ExperimentMenuUI(MouserPage):
             db = ExperimentDatabase(self.file_path)
             if db.get_number_groups() == 0:
                 messagebox.showinfo(
-                    "Groups Required",
-                    "No groups are configured yet.\n\n"
+                    parent=self.root,
+                    title="Groups Required",
+                    message="No groups are configured yet.\n\n"
                     "Create groups in Group Configuration before assigning cages.",
                 )
                 self.open_group_config()
@@ -817,22 +819,25 @@ class ExperimentMenuUI(MouserPage):
             page.raise_frame()
         except sqlite3.DatabaseError as exc:
             messagebox.showerror(
-                "Cage Configuration Error",
-                "This experiment file could not be opened as a database.\n\n"
+                parent=self.root,
+                title="Cage Configuration Error",
+                message="This experiment file could not be opened as a database.\n\n"
                 f"{exc}",
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             messagebox.showerror(
-                "Cage Configuration Error",
-                f"Failed to open Cage Configuration page.\n\n{exc}",
+                parent=self.root,
+                title="Cage Configuration Error",
+                message=f"Failed to open Cage Configuration page.\n\n{exc}",
             )
 
     def open_data_collection(self):
         """Open Data Collection Page."""
         if self.experiment_db.experiment_uses_rfid() == 1 and not self.all_rfid_mapped():
             messagebox.showinfo(
-                "RFID Mapping Required",
-                "This experiment uses RFID.\n\n"
+                parent=self.root,
+                title="RFID Mapping Required",
+                message="This experiment uses RFID.\n\n"
                 "Map RFID for all animals before starting Data Collection.",
             )
             return
@@ -851,7 +856,11 @@ class ExperimentMenuUI(MouserPage):
             )
             page.raise_frame()
         except Exception as e:  # pylint: disable=broad-exception-caught
-            messagebox.showerror("Data Collection Error", f"Failed to open Data Collection page.\n\n{e}")
+            messagebox.showerror(
+                parent=self.root,
+                title="Data Collection Error",
+                message=f"Failed to open Data Collection page.\n\n{e}",
+            )
 
     def open_data_analysis(self):
         """Open Data Analysis Page."""
@@ -924,11 +933,16 @@ class ExperimentMenuUI(MouserPage):
     def delete_warning(self):
         """Ask for confirmation before deleting the experiment file."""
         if not self.file_path:
-            messagebox.showerror("Delete Error", "No experiment file is currently loaded.")
+            messagebox.showerror(
+                parent=self.root,
+                title="Delete Error",
+                message="No experiment file is currently loaded.",
+            )
             return
         confirmed = messagebox.askyesno(
-            "Delete Experiment",
-            "This will delete the experiment file and all associated data.\n\n"
+            parent=self.root,
+            title="Delete Experiment",
+            message="This will delete the experiment file and all associated data.\n\n"
             "Are you sure you want to continue?",
         )
         if confirmed:
@@ -942,9 +956,17 @@ class ExperimentMenuUI(MouserPage):
             if os.path.exists(path):
                 os.remove(path)
             else:
-                messagebox.showwarning("Delete Warning", f"File not found:\n{path}")
+                messagebox.showwarning(
+                    parent=self.root,
+                    title="Delete Warning",
+                    message=f"File not found:\n{path}",
+                )
         except OSError as error:
-            messagebox.showerror("Delete Error", f"Failed to delete experiment:\n{error}")
+            messagebox.showerror(
+                parent=self.root,
+                title="Delete Error",
+                message=f"Failed to delete experiment:\n{error}",
+            )
             return
 
         if self.menu_page is not None and hasattr(self.menu_page, "raise_frame"):

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -682,10 +682,12 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
     def simulate_all_rfid(self):
         '''Simulates RFID for all remaining unmapped animals.'''
         confirm = CTkMessagebox(
-            title= "Confirm Simulate All",
-            message= "Are you sure you want to SimAll? \nThis should only be used in testing.",
+            master=self.parent,
+            topmost=True,
+            title="Confirm Simulate All",
+            message="Are you sure you want to SimAll? \nThis should only be used in testing.",
             option_1="No",
-            option_2="Yes"
+            option_2="Yes",
         )
         if confirm.get() == "Yes":
             self.set_reader_status("Simulating RFID mapping...")
@@ -1184,29 +1186,37 @@ class SerialSimulator():
         if len(virtual_ports) == 0:
             if platform.system() in ("Darwin", "Linux"):
                 warning = CTkMessagebox(
+                    master=self.parent,
+                    topmost=True,
                     title="Warning",
                     message="No virtual serial ports detected. Create a temporary pair now?",
                     icon="warning",
                     option_1="Cancel",
-                    option_2="Create"
+                    option_2="Create",
                 )
                 if warning.get() == "Create":
                     virtual_ports = self._start_socat_pair()
                     if len(virtual_ports) < 2:
                         CTkMessagebox(
+                            master=self.parent,
+                            topmost=True,
                             title="Error",
                             message="Unable to create virtual ports. Install socat and try again.",
-                            icon="cancel"
+                            icon="cancel",
                         )
                         return
                 else:
                     return
             else:
-                warning = CTkMessagebox(title="Warning",
-                                        message="Virtual ports missing, would you like to download the virtual ports?",
-                                        icon="warning",
-                                        option_1="Cancel",
-                                        option_2="Download")
+                warning = CTkMessagebox(
+                    master=self.parent,
+                    topmost=True,
+                    title="Warning",
+                    message="Virtual ports missing, would you like to download the virtual ports?",
+                    icon="warning",
+                    option_1="Cancel",
+                    option_2="Download",
+                )
                 if warning.get() == "Download":
                     self.download_link()
                 return
@@ -1266,9 +1276,11 @@ class SerialSimulator():
 
         if len(available_port)==0:
             CTkMessagebox(
+                master=self.parent,
+                topmost=True,
                 message="There seems to be problem with the virtual port, please submit bug report.",
                 title="Warning",
-                icon="cancel"
+                icon="cancel",
             )
 
         else:

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -14,7 +14,7 @@ from customtkinter import *
 from CTkMessagebox import CTkMessagebox
 from serial import serialutil
 from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
-from shared.tk_models import *
+from shared.tk_models import MouserPage, get_ui_metrics
 from shared.serial_port_controller import SerialPortController
 from shared.serial_handler import SerialDataHandler
 from shared.hid_wedge import HIDWedgeListener

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -12,7 +12,6 @@ import threading
 import webbrowser
 from customtkinter import *
 from CTkMessagebox import CTkMessagebox
-from playsound import playsound
 from serial import serialutil
 from shared.file_utils import SUCCESS_SOUND, ERROR_SOUND
 from shared.tk_models import *
@@ -84,6 +83,7 @@ def get_random_rfid():
 class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
     '''Map RFID user interface and window.'''
     def __init__(self, database, parent: CTk, previous_page: CTkFrame = None, file_path = ""):
+        print(f"DEBUG MapRFIDPage.__init__: database={database}, file_path={file_path}")
 
         super().__init__(parent, "RFID Mapping", previous_page)
         ui = get_ui_metrics()
@@ -144,7 +144,15 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
         self.parent = parent
 
         file = database
-        self.db = ExperimentDatabase(file)
+        print(f"DEBUG MapRFIDPage: Creating ExperimentDatabase with file={file}")
+        try:
+            self.db = ExperimentDatabase(file)
+            print(f"DEBUG MapRFIDPage: ExperimentDatabase created successfully")
+        except Exception as db_e:
+            print(f"ERROR creating ExperimentDatabase: {db_e}")
+            import traceback
+            traceback.print_exc()
+            raise
 
         self.animal_rfid_list = self.db.get_all_animals_rfid()
         self.animals = []
@@ -963,7 +971,9 @@ class MapRFIDPage(MouserPage):# pylint: disable= undefined-variable
 
     def raise_frame(self):
         '''Raise the frame for this UI'''
+        print("DEBUG MapRFIDPage.raise_frame called")
         super().raise_frame()
+        print("DEBUG MapRFIDPage.raise_frame completed")
 
     def save(self):
         '''Saves current database state to permanent file'''

--- a/shared/file_utils.py
+++ b/shared/file_utils.py
@@ -68,14 +68,14 @@ def save_temp_to_encrypted(temp_file_path: str, permanent_file_path: str, passwo
     temp_file_path = os.path.abspath(temp_file_path)
     permanent_file_path = os.path.abspath(permanent_file_path)
 
-    manager = PasswordManager(password)
+    with open(temp_file_path, 'rb') as temp_file:
+        plaintext_data = temp_file.read()
 
-    manager.encrypt_file(temp_file_path)
-    with open(temp_file_path, 'rb') as encrypted:
-        data = encrypted.read()
+    manager = PasswordManager(password)
+    encrypted_data = manager.encrypt(plaintext_data)
 
     with open(permanent_file_path, 'wb') as file:
-        file.write(data)
+        file.write(encrypted_data)
 
 def get_resource_path(relative_path):
     ''' Get the absolute path to a resource. Works for development and PyInstaller executables. '''

--- a/shared/password_utils.py
+++ b/shared/password_utils.py
@@ -17,6 +17,10 @@ class PasswordManager:
         self.key = base64.urlsafe_b64encode(self.kdf.derive(password.encode()))
         self.fernet = Fernet(self.key)
 
+    def encrypt(self, data: bytes) -> bytes:
+        '''Encrypts data and returns encrypted bytes without writing to file.'''
+        return self.fernet.encrypt(data)
+
     def encrypt_file(self,file_path):
         '''Encrypts passed file.'''
         with open(file_path, "rb") as dbfile:

--- a/shared/serial_port_settings.py
+++ b/shared/serial_port_settings.py
@@ -285,7 +285,7 @@ class SerialPortSetting(SettingPage):
         configuration_name = self.configuration_name.get().strip()
 
         if not configuration_name:
-            messagebox.showerror("Error", "Configuration name cannot be empty.", parent=self)
+            messagebox.showerror(parent=self, title="Error", message="Configuration name cannot be empty.")
             return
 
         settings = [
@@ -310,10 +310,14 @@ class SerialPortSetting(SettingPage):
                 writer = csv.writer(file)
                 writer.writerow(settings)
             print(f"Settings saved for {configuration_name}")
-            messagebox.showinfo("Success", f"Configuration '{configuration_name}' saved successfully!\n Set it as a preffered device to use it.")
+            messagebox.showinfo(
+                parent=self,
+                title="Success",
+                message=f"Configuration '{configuration_name}' saved successfully!\n Set it as a preffered device to use it.",
+            )
         except Exception as e:
             print(f"Error saving settings: {e}")
-            messagebox.showerror("Error", f"Failed to save settings: {e}")
+            messagebox.showerror(parent=self, title="Error", message=f"Failed to save settings: {e}")
 
         self.destroy()
 

--- a/ui/commands.py
+++ b/ui/commands.py
@@ -163,14 +163,32 @@ def save_file():
     print("Current file path:", current_file)
     print("Temp file path:", temp_file)
 
-    if current_file and current_file.endswith(".pmouser"):
-        file_utils.save_temp_to_encrypted(
-            temp_file,
-            current_file,
-            global_state.get("password")
-        )
-    elif current_file and temp_file:
-        file_utils.save_temp_to_file(temp_file, current_file)
-    else:
+    if not current_file or not temp_file:
         print("Save skipped — missing file path.")
+        return
+
+    # Close any open database connections to release the temp file
+    if temp_file and temp_file in ExperimentDatabase._instances:  # pylint: disable=protected-access
+        try:
+            print(f"DEBUG save_file: Closing DB connection for {temp_file}")
+            ExperimentDatabase._instances[temp_file].close()  # pylint: disable=protected-access
+            del ExperimentDatabase._instances[temp_file]  # pylint: disable=protected-access
+        except Exception as e:
+            print(f"DEBUG save_file: Error closing DB: {e}")
+
+    try:
+        if current_file.endswith(".pmouser"):
+            file_utils.save_temp_to_encrypted(
+                temp_file,
+                current_file,
+                global_state.get("password")
+            )
+        else:
+            file_utils.save_temp_to_file(temp_file, current_file)
+        print("DEBUG save_file: Save completed successfully")
+    except Exception as e:
+        print(f"DEBUG save_file: Error during save: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
 

--- a/ui/commands.py
+++ b/ui/commands.py
@@ -41,6 +41,8 @@ def open_documentation_popup(root):
     manual_path = Path(get_resource_path("docs/mouser_manual_v1.html")).resolve()
     if not manual_path.exists():
         CTkMessagebox(
+            master=root,
+            topmost=True,
             title="Documentation Not Found",
             message=f"Could not find: {manual_path}",
             icon="warning",
@@ -99,7 +101,13 @@ def open_file(root, experiments_frame):
                     raise FileNotFoundError("Temporary decrypted file not found.")
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 print(f"Decryption error: {exc}")
-                CTkMessagebox(message="Incorrect password or file error.", title="Error", icon="cancel")
+                CTkMessagebox(
+                    master=root,
+                    topmost=True,
+                    message="Incorrect password or file error.",
+                    title="Error",
+                    icon="cancel",
+                )
 
         CTkButton(password_prompt, text="OK", command=handle_password).pack()
 

--- a/ui/commands.py
+++ b/ui/commands.py
@@ -22,6 +22,7 @@ from shared.serial_port_settings import SerialPortSetting
 import shared.file_utils as file_utils
 from shared.file_utils import get_resource_path
 
+from databases.experiment_database import ExperimentDatabase
 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 from experiment_pages.create_experiment.new_experiment_ui import NewExperimentUI
 from experiment_pages.experiment.test_screen import TestScreen
@@ -59,8 +60,6 @@ def open_file(root, experiments_frame):
 
     if not file_path:
         return
-
-    from databases.experiment_database import ExperimentDatabase  # import here to avoid cycles
 
     # Close existing database connection if open
     temp_path = global_state["temp_file_path"]
@@ -129,8 +128,6 @@ def open_file(root, experiments_frame):
 
 def create_file(root, experiments_frame):
     """Handles the 'New Experiment' menu action."""
-    from databases.experiment_database import ExperimentDatabase  # pylint: disable=import-outside-toplevel
-
     temp_path = global_state["temp_file_path"]
     if temp_path and temp_path in ExperimentDatabase._instances:  # pylint: disable=protected-access
         ExperimentDatabase._instances[temp_path].close()  # pylint: disable=protected-access
@@ -191,4 +188,3 @@ def save_file():
         import traceback
         traceback.print_exc()
         raise
-


### PR DESCRIPTION
Closes #441

## Summary

- Added PasswordManager.encrypt() method to encrypt data without writing to file
- Fixed save_temp_to_encrypted() to not modify the temp file (encrypts in memory, writes only to permanent)
- Added error logging to persist function instead of silent failure

## Why?
- Root cause: encrypt_file() was modifying the temp file in-place, corrupting it with encrypted data. This broke all subsequent database operations for that session, causing buttons to stop responding.
- Silent exception handling made debugging impossible.

## How to test
1. Open an encrypted (.pmouser) experiment file with a password
2. Make any change to the notes section
3. Click "Save Note"
4. Try clicking Data Collection, Analysis, RFID Mapping buttons - they should work
5. Close the application and reopen the same file with the correct password - should work

## Checklist
- [x] python -m pytest passes (85 tests)