### PR TITLE
added topmost behavior to dialog boxes

### DIFF
--- a/experiment_pages/create_experiment/summary_ui.py
+++ b/experiment_pages/create_experiment/summary_ui.py
@@ -220,6 +220,9 @@ class SummaryUI(MouserPage):
             popup.title("Save Error")
             popup.geometry("360x180")
             popup.resizable(False, False)
+            popup.transient(self)
+            popup.attributes('-topmost', 1)
+            popup.grab_set()
 
             CTkLabel(
                 popup,
@@ -246,6 +249,8 @@ class SummaryUI(MouserPage):
         popup.title("Experiment Created")
         popup.geometry("320x160")
         popup.resizable(False, False)
+        popup.transient(self)
+        popup.attributes('-topmost', 1)
 
         def close_and_go_home():
             popup.destroy()

--- a/experiment_pages/experiment/cage_config_ui.py
+++ b/experiment_pages/experiment/cage_config_ui.py
@@ -679,6 +679,9 @@ class CageConfigurationUI(MouserPage):
         message_window.geometry('360x140')
         message_window.resizable(False, False)
         message_window.configure(fg_color=palette["bg"])
+        message_window.transient(self)
+        message_window.attributes('-topmost', 1)
+        message_window.grab_set()
 
         CTkLabel(
             message_window,

--- a/experiment_pages/experiment/data_analysis_ui.py
+++ b/experiment_pages/experiment/data_analysis_ui.py
@@ -1287,4 +1287,5 @@ class DataAnalysisUI(MouserPage):
         ok_button.pack(pady=20)
 
         notification.transient(self)
+        notification.attributes('-topmost', 1)
         notification.grab_set()

--- a/experiment_pages/experiment/data_collection_ui.py
+++ b/experiment_pages/experiment/data_collection_ui.py
@@ -2692,6 +2692,8 @@ class ChangeMeasurementsDialog():
         root.title(f"Modify Measurements for: {animal_id}")
         root.geometry("520x520")
         root.resizable(False, False)
+        root.transient(self.parent)
+        root.attributes('-topmost', 1)
         root.grid_columnconfigure(0, weight=1)
 
         CTkLabel(

--- a/experiment_pages/experiment/map_rfid.py
+++ b/experiment_pages/experiment/map_rfid.py
@@ -1044,6 +1044,9 @@ class SerialPortSelection():
         self.root = CTkToplevel(self.parent)
         self.root.title("Serial Port Selection")
         self.root.geometry('400x400')
+        self.root.transient(self.parent)
+        self.root.attributes('-topmost', 1)
+
         columns = ('port', 'description')
         self.table = Treeview(self.root, columns=columns, show='headings')
 
@@ -1217,6 +1220,8 @@ class SerialSimulator():
         self.root = CTkToplevel(self.parent)
         self.root.title("Serial Port Selection")
         self.root.geometry('400x400')
+        self.root.transient(self.parent)
+        self.root.attributes('-topmost', 1)
 
         self.read_message = CTkTextbox(self.root, height=15, width = 40)
         self.read_message.place(relx=0.10, rely = 0.00)

--- a/shared/serialSimulator.py
+++ b/shared/serialSimulator.py
@@ -15,10 +15,12 @@ class SerialSimulator():
         root = CTkToplevel(self.parent) #pylint: disable= redefined-outer-name
         root.title("Serial Port Selection")
         root.geometry('400x700')
+        root.transient(self.parent)
+        root.attributes('-topmost', 1)
 
-        self.input_entry = CTkEntry(self, width=40)
+        self.input_entry = CTkEntry(root, width=40)
         self.input_entry.place(relx=0.50, rely=0.90, anchor=CENTER)
-        self.sent_button = CTkButton(self, text = "sent", width = 15)
+        self.sent_button = CTkButton(root, text = "sent", width = 15)
         self.sent_button.place(relx=0.80, rely = 0.90, anchor=CENTER)
 
 

--- a/ui/commands.py
+++ b/ui/commands.py
@@ -73,6 +73,8 @@ def open_file(root, experiments_frame):
         password_prompt = CTkToplevel(root)
         password_prompt.title("Enter Password")
         password_prompt.geometry("300x150")
+        password_prompt.transient(root)
+        password_prompt.grab_set()
 
         CTkLabel(password_prompt, text="Enter password:").pack(pady=10)
         password_entry = CTkEntry(password_prompt, show="*")


### PR DESCRIPTION
Closes #443 

## Summary

**What changed?**
- Added the topmost attribute to all pop up dialog boxes.

**Why?**
- Previously, dialog boxes would appear behind the program, making it difficult to access them. This was problematic especially for the password dialog box.

## How to test
- Attempt to open any dialog boxes, they should appear in front of the main screen.
